### PR TITLE
✨Make plotting compatible with Jupyter notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,24 +11,27 @@ repos:
       - id: fix-encoding-pragma
         args: [--remove]
 
+  - repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.0
+    hooks:
+      - id: absolufy-imports
+
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.4
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
+
   - repo: https://github.com/python/black
     rev: 20.8b1
     hooks:
       - id: black
         language_version: python3
-        args:
-          - --line-length=88
+
   - repo: https://github.com/PyCQA/isort
     rev: 5.7.0
     hooks:
       - id: isort
-        types: [file]
-        types_or: [python, pyi]
         minimum_pre_commit_version: 2.9.0
   # - repo: https://github.com/econchick/interrogate
   #   rev: 1.3.2

--- a/pyglotaran_extras/io/load_data.py
+++ b/pyglotaran_extras/io/load_data.py
@@ -3,7 +3,7 @@ from typing import Union
 
 import xarray as xr
 
-from glotaran.analysis.result import Result
+from glotaran.project.result import Result
 
 
 def load_data(result: Union[xr.Dataset, Path, Result]):

--- a/pyglotaran_extras/plotting/plot_doas.py
+++ b/pyglotaran_extras/plotting/plot_doas.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
-
-from ..io.load_data import load_data
+from pyglotaran_extras.io.load_data import load_data
 
 
 def plot_doas(path):
@@ -23,21 +22,15 @@ def plot_doas(path):
     ax[1, 0].set_xscale("symlog", linthreshx=1)
 
     if "dampened_oscillation_associated_spectra" in dataset:
-        dataset.dampened_oscillation_cos.isel(spectral=0).sel(
-            time=slice(-1, 10)
-        ).plot.line(x="time", ax=ax[1, 1])
-        dataset.dampened_oscillation_associated_spectra.plot.line(
-            x="spectral", ax=ax[2, 0]
+        dataset.dampened_oscillation_cos.isel(spectral=0).sel(time=slice(-1, 10)).plot.line(
+            x="time", ax=ax[1, 1]
         )
+        dataset.dampened_oscillation_associated_spectra.plot.line(x="spectral", ax=ax[2, 0])
         dataset.dampened_oscillation_phase.plot.line(x="spectral", ax=ax[2, 1])
 
-    dataset.residual_left_singular_vectors.isel(left_singular_value_index=0).plot(
-        ax=ax[0, 2]
-    )
+    dataset.residual_left_singular_vectors.isel(left_singular_value_index=0).plot(ax=ax[0, 2])
     dataset.residual_singular_values.plot.line("ro-", yscale="log", ax=ax[1, 2])
-    dataset.residual_right_singular_vectors.isel(right_singular_value_index=0).plot(
-        ax=ax[2, 2]
-    )
+    dataset.residual_right_singular_vectors.isel(right_singular_value_index=0).plot(ax=ax[2, 2])
 
     interval = int(dataset.spectral.size / 11)
     for i in range(0):

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -30,15 +30,11 @@ def plot_overview(result, center_λ=None, linlog=True, linthresh=1, show_data=Fa
     plot_traces(res, ax[0, 0], center_λ, linlog=linlog, linthresh=linthresh)
     plot_spectra(res, ax[0:2, 1:3])
     plot_svd(res, ax[2:4, 0:3], linlog=linlog, linthresh=linthresh)
-    plot_residual(
-        res, ax[1, 0], linlog=linlog, linthresh=linthresh, show_data=show_data
-    )
+    plot_residual(res, ax[1, 0], linlog=linlog, linthresh=linthresh, show_data=show_data)
     plot_style.set_default_colors()
     plot_style.set_default_fontsize()
     plt.rc("axes", prop_cycle=plot_style.cycler)
     # plt.tight_layout(pad=3, w_pad=4.0, h_pad=4.0)
-    plt.draw()
-    plt.show(block=False)
     return fig
 
 

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -2,13 +2,12 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import xarray as xr
-
-from ..io.load_data import load_data
-from .plot_residual import plot_residual
-from .plot_spectra import plot_spectra
-from .plot_svd import plot_svd
-from .plot_traces import plot_traces
-from .style import PlotStyle
+from pyglotaran_extras.io.load_data import load_data
+from pyglotaran_extras.plotting.plot_residual import plot_residual
+from pyglotaran_extras.plotting.plot_spectra import plot_spectra
+from pyglotaran_extras.plotting.plot_svd import plot_svd
+from pyglotaran_extras.plotting.plot_traces import plot_traces
+from pyglotaran_extras.plotting.style import PlotStyle
 
 
 def plot_overview(result, center_λ=None, linlog=True, linthresh=1, show_data=False):

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -1,4 +1,3 @@
-import matplotlib.pyplot as plt
 import numpy as np
 
 

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -4,6 +4,7 @@ import numpy as np
 
 def plot_residual(res, ax, linlog=False, linthresh=1, show_data=False):
     data = res.data if show_data else res.residual
+    title = "dataset" if show_data else "residual"
     shape = np.array(data.shape)
     dims = data.coords.dims
     if min(shape) == 1:
@@ -16,5 +17,4 @@ def plot_residual(res, ax, linlog=False, linthresh=1, show_data=False):
         data.plot(x="time", ax=ax, add_colorbar=False)
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
-    plt.draw()
-    plt.pause(0.001)
+    ax.set_title(title)

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -1,4 +1,3 @@
-import matplotlib.pyplot as plt
 import numpy as np
 
 

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -7,8 +7,6 @@ def plot_spectra(res, axes):
     plot_das(res, axes[0, 1])
     plot_norm_sas(res, axes[1, 0])
     plot_norm_das(res, axes[1, 1])
-    plt.draw()
-    plt.pause(0.001)
 
 
 def plot_sas(res, ax, title="SAS"):
@@ -18,8 +16,6 @@ def plot_sas(res, ax, title="SAS"):
         sas.plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()
-        plt.draw()
-        plt.pause(0.001)
 
 
 def plot_norm_sas(res, ax, title="norm SAS"):
@@ -30,8 +26,6 @@ def plot_norm_sas(res, ax, title="norm SAS"):
         (sas / np.abs(sas).max(dim="spectral")).plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()
-        plt.draw()
-        plt.pause(0.001)
 
 
 def plot_das(res, ax, title="DAS"):
@@ -41,8 +35,6 @@ def plot_das(res, ax, title="DAS"):
         das.plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()
-        plt.draw()
-        plt.pause(0.001)
 
 
 def plot_norm_das(res, ax, title="norm DAS"):
@@ -52,5 +44,3 @@ def plot_norm_das(res, ax, title="norm DAS"):
         (das / np.abs(das).max(dim="spectral")).plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()
-        plt.draw()
-        plt.pause(0.001)

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -8,16 +8,14 @@ def plot_svd(res, axes, linlog=False, linthresh=1):
     plot_lsv_data(res, axes[1, 0], linlog=linlog, linthresh=linthresh)
     plot_rsv_data(res, axes[1, 1])
     plot_sv_data(res, axes[1, 2])
-    plt.draw()
-    plt.pause(0.001)
 
 
 def plot_lsv_data(res, ax, indices=range(4), linlog=False, linthresh=1):
     """ Plot left singular vectors (time) of the data matrix """
     dLSV = res.data_left_singular_vectors
-    dLSV.isel(
-        left_singular_value_index=indices[: len(dLSV.left_singular_value_index)]
-    ).plot.line(x="time", ax=ax)
+    dLSV.isel(left_singular_value_index=indices[: len(dLSV.left_singular_value_index)]).plot.line(
+        x="time", ax=ax
+    )
     ax.set_title("data. LSV")
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
@@ -41,17 +39,15 @@ def plot_sv_data(res, ax, indices=range(10)):
     ax.set_title("data. log(SV)")
 
 
-def plot_lsv_residual(
-    res, ax, indices=range(2), label="residual", linlog=False, linthresh=1
-):
+def plot_lsv_residual(res, ax, indices=range(2), label="residual", linlog=False, linthresh=1):
     """ Plot left singular vectors (time) of the residual matrix """
     if "weighted_residual_left_singular_vectors" in res:
         rLSV = res.weighted_residual_left_singular_vectors
     else:
         rLSV = res.residual_left_singular_vectors
-    rLSV.isel(
-        left_singular_value_index=indices[: len(rLSV.left_singular_value_index)]
-    ).plot.line(x="time", ax=ax)
+    rLSV.isel(left_singular_value_index=indices[: len(rLSV.left_singular_value_index)]).plot.line(
+        x="time", ax=ax
+    )
     ax.set_title("res. LSV")
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -1,6 +1,3 @@
-import matplotlib.pyplot as plt
-
-
 def plot_svd(res, axes, linlog=False, linthresh=1):
     plot_lsv_residual(res, axes[0, 0], linlog=linlog, linthresh=linthresh)
     plot_rsv_residual(res, axes[0, 1])

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -9,9 +9,7 @@ def get_shifted_traces(res, center_λ=None):
     if center_λ is None:  # center wavelength (λ in nm)
         center_λ = min(res.dims["spectral"], round(res.dims["spectral"] / 2))
     if "center_dispersion_1" in res:
-        center_dispersion = (
-            res.center_dispersion_1
-        )  # TODO: clarify against pyglotaran API why _1?
+        center_dispersion = res.center_dispersion_1  # TODO: clarify against pyglotaran API why _1?
         irf_loc = center_dispersion.sel(spectral=center_λ, method="nearest").item()
     elif "irf_center" in res:
         irf_loc = res.irf_center
@@ -41,6 +39,3 @@ def plot_traces(res, ax, center_λ, linlog=False, linthresh=1, linscale=1):
 
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh, linscale=linscale)
-
-    plt.draw()
-    plt.pause(0.005)

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
-
-from .style import PlotStyle
+from pyglotaran_extras.plotting.style import PlotStyle
 
 
 def get_shifted_traces(res, center_λ=None):

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()


### PR DESCRIPTION
Removing the calls to `plt.draw()` makes plots work properly in notebooks.

Tested in:
- Notebooks
- Scripts
- VS-Code interactive mode

The downside is that you won't see anything happening till all plots are done.
But since this PR removes the calls to `plt.pause(0.001)` and `plt.draw()` ([which redraws the whole figure](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.draw.html)) the plots in general is faster.