### PR TITLE
🩹 Fix tests on none windows platform

### DIFF
--- a/tests/io/test_boilerplate.py
+++ b/tests/io/test_boilerplate.py
@@ -40,7 +40,7 @@ def test_get_script_dir_tmp_path(tmp_path: Path):
     )
     tmp_file.write_text(content)
     printed_result = subprocess.run(
-        [sys.executable, tmp_file.resolve().as_posix()], capture_output=True, shell=True
+        " ".join([sys.executable, tmp_file.resolve().as_posix()]), capture_output=True, shell=True
     )
     result = printed_result.stdout.decode().rstrip("\n\r")
 


### PR DESCRIPTION
Yeah, should have tested it on WSL2 before ... kinda annoying that when using `shell=True` you need to differentiate between OS but oh well.
This time I tested it on:
- WSL2
- git bash
- conda cmd

### Change summary

- Changed subprocess call to use `str` instead of `list`

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
