### PR TITLE
🩹 Remove upper pyglotaran version limit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 packages = find:
 install_requires =
     matplotlib>=3.3.0
-    pyglotaran>=0.3.0,<0.5.0
+    pyglotaran>=0.3.0
 python_requires = >=3.8,<3.10
 zip_safe = True
 


### PR DESCRIPTION
The upper pyglotaran limit causes the `pyglotaran/examples` action to uninstall the current pyglotaran version and use an old one. This leads to false-positive tests.
Also the upper limit isn't needed anymore since pyglotaran now uses a proper deprecation system.

### Change summary

- Removed upper pyglotaran limit for the package


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
