### PR TITLE
🩹 Fix irf location selection for irfs with multiple components

### DIFF
--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -47,7 +47,7 @@ def get_shifted_traces(
 
     if "irf_center_location" in res:
         irf_center_location = res.irf_center_location
-        irf_loc = irf_center_location.sel(spectral=center_λ, method="nearest").item()
+        irf_loc = irf_center_location.sel(spectral=center_λ, method="nearest")
     elif "center_dispersion_1" in res:
         # legacy compatibility pyglotaran<0.5.0
         center_dispersion = res.center_dispersion_1
@@ -58,7 +58,7 @@ def get_shifted_traces(
         irf_loc = min(times)
 
     if hasattr(irf_loc, "shape") and len(irf_loc.shape) > 0:
-        irf_loc = irf_loc[main_irf_nr]
+        irf_loc = irf_loc[main_irf_nr].item()
 
     times_shifted = times - irf_loc
     return traces.assign_coords(time=times_shifted)


### PR DESCRIPTION
Follow up PR for #30

Since the [DPSI case study](https://github.com/s-weigand/pyglotaran-examples/blob/notebooks/notebooks/DPSI/DPSI_case_study.ipynb) was broken until https://github.com/glotaran/pyglotaran/pull/797 we didn't see that the plottings breaks.

I tested it against all the notebooks on my notebook branch and examples on `pyglotaran-examples` main branch.

### Change summary

- Fix irf location selection for irfs with multiple components

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
