### PR TITLE
🩹 Fix 'setup_case_study' when used with 'results_folder_root'

### DIFF
--- a/pyglotaran_extras/io/setup_case_study.py
+++ b/pyglotaran_extras/io/setup_case_study.py
@@ -41,7 +41,7 @@ def setup_case_study(
     if results_folder_root is None:
         results_folder_root = Path.home() / output_folder_name
     else:
-        results_folder_root = Path(str(results_folder_root))
+        results_folder_root = Path(str(results_folder_root)) / output_folder_name
     script_folder_rel = analysis_folder.relative_to(analysis_folder.parent)
     results_folder = (results_folder_root / script_folder_rel).resolve()
     results_folder.mkdir(parents=True, exist_ok=True)

--- a/tests/io/test_setup_case_study.py
+++ b/tests/io/test_setup_case_study.py
@@ -66,7 +66,7 @@ def test_setup_case_study_custom(tmp_path: Path):
     results_folder_root = tmp_path / "foo"
 
     results_folder, script_folder = setup_case_study(
-        output_folder_name="foo", results_folder_root=results_folder_root
+        output_folder_name="foo", results_folder_root=tmp_path
     )
 
     assert results_folder_root.exists()


### PR DESCRIPTION
When using `setup_case_study` with `results_folder_root`, the `output_folder_name` is ignored.

This slipped because in the examples `results_folder_root` is always `None` (uses user home folder) and the test was wrong.

### Change summary

- 🩹 Also use `output_folder_name`  when `results_folder_root` not `None` 

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
