### PR TITLE
🩹 Fix broken 'plot_data_overview'

### DIFF
--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -6,6 +6,7 @@ from typing import cast
 import matplotlib.pyplot as plt
 from matplotlib.axis import Axis
 
+from pyglotaran_extras.io.load_data import load_data
 from pyglotaran_extras.plotting.plot_svd import plot_lsv_data
 from pyglotaran_extras.plotting.plot_svd import plot_rsv_data
 from pyglotaran_extras.plotting.plot_svd import plot_sv_data
@@ -13,13 +14,14 @@ from pyglotaran_extras.plotting.plot_svd import plot_sv_data
 __all__ = ["plot_data_overview"]
 
 if TYPE_CHECKING:
-    import xarray as xr
     from matplotlib.figure import Figure
     from matplotlib.pyplot import Axes
 
+    from pyglotaran_extras.types import DatasetConvertible
+
 
 def plot_data_overview(
-    dataset: xr.Dataset,
+    dataset: DatasetConvertible,
     title: str = "Data overview",
     linlog: bool = False,
     linthresh: float = 1,
@@ -29,7 +31,7 @@ def plot_data_overview(
 
     Parameters
     ----------
-    dataset : Dataset
+    dataset : DatasetConvertible
         Dataset containing data and SVD of the data.
     title : str, optional
         Title to add to the figure., by default "Data overview"
@@ -44,6 +46,8 @@ def plot_data_overview(
     tuple[Figure, Axes]
         Figure and axes which can then be refined by the user.
     """
+    dataset = load_data(dataset)
+
     fig = plt.figure(figsize=figsize)
     data_ax = cast(Axis, plt.subplot2grid((4, 3), (0, 0), colspan=3, rowspan=3, fig=fig))
     lsv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 0), fig=fig))


### PR DESCRIPTION
In #40 when adding the typing I imported `cast` and `Axis` inside the `if TYPE_CHECKING` block, which doesn't make them available during runtime, and broke `plot_data_overview`.

### Change summary

- 🩹 Moved imports needed at runtime up from TYPE_CHECKING if block
- :ok_hand: Changed default figsize of plot_data_overview to (15, 10))
- :ok_hand: Changed dataset in plot_data_overview to also be allowed to be a path

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)