### PR TITLE
🩹🚇 Fix release pipeline not running on push tag

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,8 @@ name: "Run Examples"
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: "Tests"
 
 on:
   push:
+    tags:
+      - v**
     branches-ignore:
       - "dependabot/**"
   pull_request:


### PR DESCRIPTION
Looks like specifying `branches-ignore` on the push event also prevents it from running on pushed tags.
This prevents the release workflow from publishing to PyPI.

### Change summary

- [🩹🚇 Fixed release pipeline not running on push tag](https://github.com/glotaran/pyglotaran-extras/commit/4c52b7071ca6dcaab5103b4033708fd7bc47a6b7)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)