### PR TITLE
🩹 Fix autogenerated title for concentration plot

### DIFF
--- a/pyglotaran_extras/plotting/plot_concentrations.py
+++ b/pyglotaran_extras/plotting/plot_concentrations.py
@@ -22,6 +22,7 @@ def plot_concentrations(
     linscale: float = 1,
     main_irf_nr: int = 0,
     cycler: Cycler | None = PlotStyle().cycler,
+    title: str = "Concentrations",
 ) -> None:
     """Plot traces on the given axis ``ax``.
 
@@ -50,6 +51,8 @@ def plot_concentrations(
         parametrized with multiple peaks. Defaults to 0.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
+    title: str
+        Title used for the plot axis. Defaults to "Concentrations".
 
     See Also
     --------
@@ -62,6 +65,7 @@ def plot_concentrations(
         traces.sel(spectral=center_λ, method="nearest").plot.line(x="time", ax=ax)
     else:
         traces.plot.line(x="time", ax=ax)
+    ax.set_title(title)
 
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh, linscale=linscale)


### PR DESCRIPTION
Since we don't set the title for concentration plots they are left with the autogenerated ones by xarray.

Before:
![grafik](https://user-images.githubusercontent.com/9513634/157524318-7b3e602b-4a6b-403c-91e9-7f48b52565c5.png)

After:
![grafik](https://user-images.githubusercontent.com/9513634/157524273-a80f1f2f-dff5-451a-8a54-15d8d411a3cb.png)



### Change summary

- [🩹 Fixed autogenerated title for concentration plot](https://github.com/glotaran/pyglotaran-extras/commit/c2d089d6ec7393fea6658da7ae7e3d88dfe0419a)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [🩹 Fixed autogenerated title for concentration plot](https://github.com/glotaran/pyglotaran-extras/commit/c2d089d6ec7393fea6658da7ae7e3d88dfe0419a)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
