### PR TITLE
Improve svd plotting

### DIFF
--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -28,6 +28,7 @@ def plot_data_overview(
     linlog: bool = False,
     linthresh: float = 1,
     figsize: tuple[int, int] = (15, 10),
+    nr_of_data_svd_vectors: int = 4,
 ) -> tuple[Figure, Axes]:
     """Plot data as filled contour plot and SVD components.
 
@@ -44,6 +45,8 @@ def plot_data_overview(
         This avoids having the plot go to infinity around zero. Defaults to 1.
     figsize : tuple[int, int]
         Size of the figure (N, M) in inches. Defaults to (15, 10).
+    nr_of_data_svd_vectors: int
+        Number of data SVD vector to plot. Defaults to 4.
 
     Returns
     -------
@@ -64,9 +67,9 @@ def plot_data_overview(
         dataset.data.plot(ax=data_ax)
 
     add_svd_to_dataset(dataset=dataset, name="data")
-    plot_lsv_data(dataset, lsv_ax)
+    plot_lsv_data(dataset, lsv_ax, indices=range(nr_of_data_svd_vectors))
     plot_sv_data(dataset, sv_ax)
-    plot_rsv_data(dataset, rsv_ax)
+    plot_rsv_data(dataset, rsv_ax, indices=range(nr_of_data_svd_vectors))
     fig.suptitle(title, fontsize=16)
     fig.tight_layout()
 

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -36,6 +36,8 @@ def plot_overview(
     figsize: tuple[int, int] = (18, 16),
     cycler: Cycler | None = PlotStyle().cycler,
     figure_only: bool = True,
+    nr_of_data_svd_vectors: int = 2,
+    nr_of_residual_svd_vectors: int = 2,
 ) -> Figure | tuple[Figure, Axes]:
     """Plot overview of the optimization result.
 
@@ -70,6 +72,10 @@ def plot_overview(
         Whether or not to only return the figure.
         This is a deprecation helper argument to transition to a consistent return value
         consisting of the :class:`Figure` and the :class:`Axes`. Defaults to True.
+    nr_of_data_svd_vectors: int
+        Number of data SVD vector to plot. Defaults to 2.
+    nr_of_residual_svd_vectors: int
+        Number of residual SVD vector to plot. Defaults to 2.
 
     Returns
     -------
@@ -99,7 +105,15 @@ def plot_overview(
         cycler=cycler,
     )
     plot_spectra(res, axes[0:2, 1:3], cycler=cycler)
-    plot_svd(res, axes[2:4, 0:3], linlog=linlog, linthresh=linthresh, cycler=cycler)
+    plot_svd(
+        res,
+        axes[2:4, 0:3],
+        linlog=linlog,
+        linthresh=linthresh,
+        cycler=cycler,
+        nr_of_data_svd_vectors=nr_of_data_svd_vectors,
+        nr_of_residual_svd_vectors=nr_of_residual_svd_vectors,
+    )
     plot_residual(
         res, axes[1, 0], linlog=linlog, linthresh=linthresh, show_data=show_data, cycler=cycler
     )

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -23,6 +23,8 @@ def plot_svd(
     linlog: bool = False,
     linthresh: float = 1,
     cycler: Cycler | None = PlotStyle().cycler,
+    nr_of_data_svd_vectors: int = 2,
+    nr_of_residual_svd_vectors: int = 2,
 ) -> None:
     """Plot SVD (Singular Value Decomposition) of data and residual.
 
@@ -39,17 +41,35 @@ def plot_svd(
         This avoids having the plot go to infinity around zero. Defaults to 1.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
+    nr_of_data_svd_vectors: int
+        Number of data SVD vector to plot. Defaults to 2.
+    nr_of_residual_svd_vectors: int
+        Number of residual SVD vector to plot. Defaults to 2.
     """
     if "weighted_residual" in res:
         add_svd_to_dataset(dataset=res, name="weighted_residual")
     else:
         add_svd_to_dataset(dataset=res, name="residual")
-    plot_lsv_residual(res, axes[0, 0], linlog=linlog, linthresh=linthresh, cycler=cycler)
-    plot_rsv_residual(res, axes[0, 1], cycler=cycler)
+    plot_lsv_residual(
+        res,
+        axes[0, 0],
+        linlog=linlog,
+        linthresh=linthresh,
+        cycler=cycler,
+        indices=range(nr_of_residual_svd_vectors),
+    )
+    plot_rsv_residual(res, axes[0, 1], cycler=cycler, indices=range(nr_of_residual_svd_vectors))
     plot_sv_residual(res, axes[0, 2], cycler=cycler)
     add_svd_to_dataset(dataset=res, name="data")
-    plot_lsv_data(res, axes[1, 0], linlog=linlog, linthresh=linthresh, cycler=cycler)
-    plot_rsv_data(res, axes[1, 1], cycler=cycler)
+    plot_lsv_data(
+        res,
+        axes[1, 0],
+        linlog=linlog,
+        linthresh=linthresh,
+        cycler=cycler,
+        indices=range(nr_of_data_svd_vectors),
+    )
+    plot_rsv_data(res, axes[1, 1], cycler=cycler, indices=range(nr_of_data_svd_vectors))
     plot_sv_data(res, axes[1, 2], cycler=cycler)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ no_implicit_optional = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
 disallow_untyped_calls = True
-no_implicit_reexport = Ture
+no_implicit_reexport = True
 warn_unused_configs = True
 
 [mypy-tests.*]


### PR DESCRIPTION
This PR fixes #50 and also adds arguments to specify the number of residual vectors to plot.

As an additional bonus `plot_lsv_data` and `plot_rsv_data` are now agnostic towards the x dimensions name, since the x dimension selection works by using `not sv_index_dim`.

Before:
![grafik](https://user-images.githubusercontent.com/9513634/157661155-dff24065-b4f2-4b46-a0b5-142cc1d266b8.png)
![grafik](https://user-images.githubusercontent.com/9513634/157661281-dd3ac357-1739-47be-9b03-33abcd7c0cdb.png)

After:
![grafik](https://user-images.githubusercontent.com/9513634/157661653-41a519b7-dee4-40c0-b3c8-85811635febc.png)
![grafik](https://user-images.githubusercontent.com/9513634/157661725-6cad96b5-259d-4773-85d5-1d79b9eb02a0.png)


### Change summary

- [👌 Changed SDV vector plotting to use reversed zorder](https://github.com/glotaran/pyglotaran-extras/commit/10fdc6787d9a5a0bb4cb854a54c7f41972bc1824)
- [👌Added nr of SVD vector arguments to plot_data_overview and plot_overview](https://github.com/glotaran/pyglotaran-extras/commit/784cd81a5cb43ac043b2dafe8bcc8dd8439e6913)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #50
