### PR TITLE
🔧🩹 Remove github section in sourcery config due to bug in sourcery-ai

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -10,9 +10,3 @@ clone_detection:
   min_lines: 3
   min_duplicates: 2
   identical_clones_only: false
-
-github:
-  labels: []
-  ignore_labels: [sourcery-ignore]
-  request_review: author
-  sourcery_branch: sourcery/{base_branch}


### PR DESCRIPTION
Looks like sourcery AI won't refactor branches when the github section is in the config.

My guess is that `sourcery_branch: sourcery/{base_branch}` isn't handled gracefully, when not triggered by a webhook (`KeyError` ?).

### Change summary

- [🩹 Remove github section in sourcery config due to bug in sourcery-ai](https://github.com/glotaran/pyglotaran-extras/commit/362b2259505cbc45431b3918c95860a6023575b4)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)