### PR TITLE
👌 Improve legend placement in plot_data_overview

### DIFF
--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -60,6 +60,7 @@ def plot_data_overview(
 
     fig = plt.figure(figsize=figsize)
     data_ax = cast(Axis, plt.subplot2grid((4, 3), (0, 0), colspan=3, rowspan=3, fig=fig))
+    fig.subplots_adjust(hspace=0.5, wspace=0.25)
     lsv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 0), fig=fig))
     sv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 1), fig=fig))
     rsv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 2), fig=fig))
@@ -70,15 +71,12 @@ def plot_data_overview(
         dataset.data.plot(ax=data_ax)
 
     add_svd_to_dataset(dataset=dataset, name="data")
-    plot_lsv_data(
-        dataset, lsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=show_data_svd_legend
-    )
+    plot_lsv_data(dataset, lsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=False)
     plot_sv_data(dataset, sv_ax)
-    plot_rsv_data(
-        dataset, rsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=show_data_svd_legend
-    )
+    plot_rsv_data(dataset, rsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=False)
+    if show_data_svd_legend is True:
+        rsv_ax.legend(title="singular value index", loc="lower right", bbox_to_anchor=(1.13, 1))
     fig.suptitle(title, fontsize=16)
-    fig.tight_layout()
 
     if linlog:
         data_ax.set_xscale("symlog", linthresh=linthresh)


### PR DESCRIPTION
Just some minor improvements on pacing legends for `plot_data_overview`

### Before
Legend hides part of the plot and has redundant information since the legends for LSV and RSV link the same color to the same index.
![image](https://user-images.githubusercontent.com/9513634/162563383-c5295b58-b356-459c-8a3c-c7d6f17f086f.png)

When users want to plot more vectors things get out of control
![image](https://user-images.githubusercontent.com/9513634/162563359-9bba0bc4-052e-4517-8a79-21a7b7c0ef9d.png)


### After
![image](https://user-images.githubusercontent.com/9513634/162564082-25e0f288-c95d-4d12-aad2-421b2645834e.png)


Also plays nicely if users want to plot more vectors
![image](https://user-images.githubusercontent.com/9513634/162564044-e535b706-665d-425e-a783-9b05ebb84a47.png)



### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)

