### PR TITLE
🚇👌 Exclude pre-commit and sourcery branches from CI push run

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
+      - "sourcery/**"
+      - "pre-commit-ci-update-config"
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - v**
     branches-ignore:
       - "dependabot/**"
+      - "sourcery/**"
+      - "pre-commit-ci-update-config"
   pull_request:
 
 jobs:


### PR DESCRIPTION
Since bots push to the repo and create PRs there is no need to also check their pushes, the PRevent is enougth.

### Change summary

- [🚇👌 Exclude pre-commit and sourcery branches from CI push run](https://github.com/glotaran/pyglotaran-extras/commit/d5189f345373d484220871d50f117088f8553c4a)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)