### PR TITLE
👌🚇 Change integration tests to use self managed examples action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,25 +10,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  create-example-list:
+    name: Create Example List
+    runs-on: ubuntu-latest
+    outputs:
+      example-list: ${{ steps.create-example-list.outputs.example-list }}
+    steps:
+      - name: Set example list output
+        id: create-example-list
+        uses: glotaran/pyglotaran-examples@main
+        with:
+          example_name: set example list
+          set_example_list: true
+
   run-examples:
     name: "Run Example: "
     runs-on: ubuntu-latest
+    needs: [create-example-list]
     strategy:
       matrix:
-        example_name:
-          [
-            quick-start,
-            fluorescence,
-            transient-absorption,
-            transient-absorption-two-datasets,
-            spectral-constraints,
-            spectral-guidance,
-            two-datasets,
-            sim-3d-disp,
-            sim-3d-nodisp,
-            sim-3d-weight,
-            sim-6d-disp,
-          ]
+        example_name: ${{fromJson(needs.create-example-list.outputs.example-list)}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8


### PR DESCRIPTION
This way the integration tests will manage the list of examples that will be run by themselves and won't forget any.

### Change summary

- [👌🚇 Change integration tests to use self managed examples action](https://github.com/glotaran/pyglotaran-extras/commit/506ccc5db83ec3aa841066b33c1f1e19a5e92001)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)