### PR TITLE
👌 Fix typo in internal function name

### DIFF
--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -124,7 +124,7 @@ def plot_lsv_data(
     """
     add_cycler_if_not_none(ax, cycler)
     dLSV = res.data_left_singular_vectors
-    _plot_svd_vetors(dLSV, indices, "left_singular_value_index", ax, show_legend)
+    _plot_svd_vectors(dLSV, indices, "left_singular_value_index", ax, show_legend)
     ax.set_title("data. LSV")
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
@@ -154,7 +154,7 @@ def plot_rsv_data(
     """
     add_cycler_if_not_none(ax, cycler)
     dRSV = res.data_right_singular_vectors
-    _plot_svd_vetors(dRSV, indices, "right_singular_value_index", ax, show_legend)
+    _plot_svd_vectors(dRSV, indices, "right_singular_value_index", ax, show_legend)
     ax.set_title("data. RSV")
 
 
@@ -219,7 +219,7 @@ def plot_lsv_residual(
         rLSV = res.weighted_residual_left_singular_vectors
     else:
         rLSV = res.residual_left_singular_vectors
-    _plot_svd_vetors(rLSV, indices, "left_singular_value_index", ax, show_legend)
+    _plot_svd_vectors(rLSV, indices, "left_singular_value_index", ax, show_legend)
     ax.set_title("res. LSV")
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
@@ -252,7 +252,7 @@ def plot_rsv_residual(
         rRSV = res.weighted_residual_right_singular_vectors
     else:
         rRSV = res.residual_right_singular_vectors
-    _plot_svd_vetors(rRSV, indices, "right_singular_value_index", ax, show_legend)
+    _plot_svd_vectors(rRSV, indices, "right_singular_value_index", ax, show_legend)
     ax.set_title("res. RSV")
 
 
@@ -286,7 +286,7 @@ def plot_sv_residual(
     ax.set_title("res. log(SV)")
 
 
-def _plot_svd_vetors(
+def _plot_svd_vectors(
     vector_data: xr.DataArray,
     indices: Sequence[int],
     sv_index_dim: str,


### PR DESCRIPTION
Just fixed a typo (introduced by me) that bugged me 😅

### Change summary

- [👌 Fixed typo in internal function name](https://github.com/glotaran/pyglotaran-extras/commit/cb3c7438a00d0bd221e8dcf5278107a19b2268bc)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)