### PR TITLE
👌 Shift time axis by IRF location

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip: [flake8]
+
 repos:
   # Formatters
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -12,6 +12,7 @@ from pyglotaran_extras.io.load_data import load_data
 from pyglotaran_extras.plotting.plot_svd import plot_lsv_data
 from pyglotaran_extras.plotting.plot_svd import plot_rsv_data
 from pyglotaran_extras.plotting.plot_svd import plot_sv_data
+from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 
 __all__ = ["plot_data_overview"]
 
@@ -31,6 +32,7 @@ def plot_data_overview(
     figsize: tuple[int, int] = (15, 10),
     nr_of_data_svd_vectors: int = 4,
     show_data_svd_legend: bool = True,
+    irf_location: float | None = None,
 ) -> tuple[Figure, Axes]:
     """Plot data as filled contour plot and SVD components.
 
@@ -51,6 +53,9 @@ def plot_data_overview(
         Number of data SVD vector to plot. Defaults to 4.
     show_data_svd_legend: bool
         Whether or not to show the data SVD legend. Defaults to True.
+    irf_location:  float | None
+        Location of the ``irf`` by which the time axis will get shifted. If it is None the time
+        axis will not be shifted. Defaults to None.
 
     Returns
     -------
@@ -66,13 +71,21 @@ def plot_data_overview(
     sv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 1), fig=fig))
     rsv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 2), fig=fig))
 
-    if len(dataset.data.time) > 1:
-        dataset.data.plot(x="time", ax=data_ax, center=False)
+    data = shift_time_axis_by_irf_location(dataset.data, irf_location)
+
+    if len(data.time) > 1:
+        data.plot(x="time", ax=data_ax, center=False)
     else:
-        dataset.data.plot(ax=data_ax)
+        data.plot(ax=data_ax)
 
     add_svd_to_dataset(dataset=dataset, name="data")
-    plot_lsv_data(dataset, lsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=False)
+    plot_lsv_data(
+        dataset,
+        lsv_ax,
+        indices=range(nr_of_data_svd_vectors),
+        show_legend=False,
+        irf_location=irf_location,
+    )
     plot_sv_data(dataset, sv_ax)
     plot_rsv_data(dataset, rsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=False)
     if show_data_svd_legend is True:

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -84,6 +84,8 @@ def plot_data_overview(
         lsv_ax,
         indices=range(nr_of_data_svd_vectors),
         show_legend=False,
+        linlog=linlog,
+        linthresh=linthresh,
         irf_location=irf_location,
     )
     plot_sv_data(dataset, sv_ax)

--- a/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
+++ b/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
@@ -29,6 +29,7 @@ def plot_irf_dispersion_center(
     ax: Axis | None = None,
     figsize: tuple[int, int] = (12, 8),
     cycler: Cycler | None = PlotStyle().cycler,
+    irf_location: float | None = None,
 ) -> tuple[Figure, Axis] | None:
     """Plot the IRF dispersion center over the spectral dimension for one or multiple datasets.
 
@@ -42,6 +43,9 @@ def plot_irf_dispersion_center(
         Size of the figure (N, M) in inches. Defaults to (12, 8).
     cycler: Cycler
         Plot style cycler to use. Defaults to PlotStyle().cycler
+    irf_location:  float | None
+        Location of the ``irf`` by which the time axis will get shifted. If it is None the time
+        axis will not be shifted. Defaults to None.
 
     Returns
     -------
@@ -56,7 +60,12 @@ def plot_irf_dispersion_center(
         axis = ax
     for dataset_name, dataset in result_map.items():
         _plot_irf_dispersion_center(
-            dataset, axis, spectral_axis="x", cycler=cycler, label=dataset_name
+            dataset,
+            axis,
+            spectral_axis="x",
+            cycler=cycler,
+            label=dataset_name,
+            irf_location=irf_location,
         )
     axis.legend()
 
@@ -73,6 +82,7 @@ def _plot_irf_dispersion_center(
     spectral_axis: Literal["x", "y"] = "x",
     cycler: Cycler | None = PlotStyle().cycler,
     label: str = "IRF",
+    irf_location: float | None = None,
 ) -> None:
     """Plot the IRF dispersion center on an Axis ``ax``.
 
@@ -90,7 +100,13 @@ def _plot_irf_dispersion_center(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     label: str
         Plot label for the IRF shown in the legend. Defaults to "IRF"
+    irf_location:  float | None
+        Location of the ``irf`` by which the time axis (here values) will get shifted.
+        If it is None the time axis will not be shifted. Defaults to None.
     """
     add_cycler_if_not_none(ax, cycler)
     irf = cast(xr.DataArray, extract_irf_dispersion_center(res, as_dataarray=True))
-    irf.plot(ax=ax, label=label, **{spectral_axis: "spectral"})
+    if irf_location is not None:
+        (irf - irf_location).plot(ax=ax, label=label, **{spectral_axis: "spectral"})
+    else:
+        irf.plot(ax=ax, label=label, **{spectral_axis: "spectral"})

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -20,6 +20,7 @@ from pyglotaran_extras.plotting.plot_svd import plot_rsv_residual
 from pyglotaran_extras.plotting.plot_svd import plot_svd
 from pyglotaran_extras.plotting.style import PlotStyle
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
+from pyglotaran_extras.plotting.utils import extract_irf_location
 
 if TYPE_CHECKING:
     from cycler import Cycler
@@ -111,6 +112,8 @@ def plot_overview(
     N = 3
     fig, axes = plt.subplots(M, N, figsize=figsize, constrained_layout=True)
 
+    irf_location = extract_irf_location(res, center_λ, main_irf_nr)
+
     if center_λ is None:  # center wavelength (λ in nm)
         center_λ = min(res.dims["spectral"], round(res.dims["spectral"] / 2))
 
@@ -136,6 +139,7 @@ def plot_overview(
         nr_of_residual_svd_vectors=nr_of_residual_svd_vectors,
         show_data_svd_legend=show_data_svd_legend,
         show_residual_svd_legend=show_residual_svd_legend,
+        irf_location=irf_location,
     )
     plot_residual(
         res,
@@ -145,6 +149,7 @@ def plot_overview(
         show_data=show_data,
         cycler=cycler,
         show_irf_dispersion_center=show_irf_dispersion_center,
+        irf_location=irf_location,
     )
     if figure_only is False:
         return fig, axes
@@ -197,14 +202,24 @@ def plot_simple_overview(
     plot_concentrations(res, ax=axes[0, 0], center_λ=res.coords["spectral"].values[0])
     plot_sas(res, ax=axes[0, 1])
 
-    plot_lsv_residual(res, ax=axes[1, 0])
+    irf_location = extract_irf_location(res, center_λ=res.coords["spectral"].values[0])
+
+    plot_lsv_residual(res, ax=axes[1, 0], irf_location=irf_location)
     plot_rsv_residual(res, ax=axes[1, 1])
 
     plot_residual(
-        res, axes[0, 2], show_data=True, show_irf_dispersion_center=show_irf_dispersion_center
+        res,
+        axes[0, 2],
+        show_data=True,
+        show_irf_dispersion_center=show_irf_dispersion_center,
+        irf_location=irf_location,
     )
     plot_residual(
-        res, axes[1, 2], show_data=False, show_irf_dispersion_center=show_irf_dispersion_center
+        res,
+        axes[1, 2],
+        show_data=False,
+        show_irf_dispersion_center=show_irf_dispersion_center,
+        irf_location=irf_location,
     )
 
     if figure_only is not True:

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -8,6 +8,7 @@ import numpy as np
 from pyglotaran_extras.plotting.plot_irf_dispersion_center import _plot_irf_dispersion_center
 from pyglotaran_extras.plotting.style import PlotStyle
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
+from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 
 if TYPE_CHECKING:
     import xarray as xr
@@ -23,6 +24,7 @@ def plot_residual(
     show_data: bool = False,
     cycler: Cycler | None = PlotStyle().cycler,
     show_irf_dispersion_center: bool = True,
+    irf_location: float | None = None,
 ) -> None:
     """Plot data or residual on a 2D contour plot.
 
@@ -44,9 +46,13 @@ def plot_residual(
     show_irf_dispersion_center: bool
         Whether to show the the IRF dispersion center as overlay on the residual/data plot.
         Defaults to True.
+    irf_location:  float | None
+        Location of the ``irf`` by which the time axis will get shifted. If it is None the time
+        axis will not be shifted. Defaults to None.
     """
     add_cycler_if_not_none(ax, cycler)
     data = res.data if show_data else res.residual
+    data = shift_time_axis_by_irf_location(data, irf_location)
     title = "dataset" if show_data else "residual"
     shape = np.array(data.shape)
     dims = data.coords.dims
@@ -58,7 +64,9 @@ def plot_residual(
     else:
         data.plot(x="time", ax=ax, add_colorbar=False)
     if show_irf_dispersion_center is True:
-        _plot_irf_dispersion_center(res, ax=ax, spectral_axis="y", cycler=cycler)
+        _plot_irf_dispersion_center(
+            res, ax=ax, spectral_axis="y", cycler=cycler, irf_location=irf_location
+        )
         ax.set_xlabel("time")
         ax.legend()
     if linlog:

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -7,6 +7,7 @@ from glotaran.io.prepare_dataset import add_svd_to_dataset
 
 from pyglotaran_extras.plotting.style import PlotStyle
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
+from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -27,6 +28,7 @@ def plot_svd(
     nr_of_residual_svd_vectors: int = 2,
     show_data_svd_legend: bool = True,
     show_residual_svd_legend: bool = True,
+    irf_location: float | None = None,
 ) -> None:
     """Plot SVD (Singular Value Decomposition) of data and residual.
 
@@ -51,6 +53,9 @@ def plot_svd(
         Whether or not to show the data SVD legend. Defaults to True.
     show_residual_svd_legend: bool
         Whether or not to show the residual SVD legend. Defaults to True.
+    irf_location:  float | None
+        Location of the ``irf`` by which the time axis will get shifted. If it is None the time
+        axis will not be shifted. Defaults to None.
     """
     if "weighted_residual" in res:
         add_svd_to_dataset(dataset=res, name="weighted_residual")
@@ -64,6 +69,7 @@ def plot_svd(
         cycler=cycler,
         indices=range(nr_of_residual_svd_vectors),
         show_legend=show_residual_svd_legend,
+        irf_location=irf_location,
     )
     plot_rsv_residual(
         res,
@@ -82,6 +88,7 @@ def plot_svd(
         cycler=cycler,
         indices=range(nr_of_data_svd_vectors),
         show_legend=show_data_svd_legend,
+        irf_location=irf_location,
     )
     plot_rsv_data(
         res,
@@ -101,6 +108,7 @@ def plot_lsv_data(
     linthresh: float = 1,
     cycler: Cycler | None = PlotStyle().cycler,
     show_legend: bool = True,
+    irf_location: float | None = None,
 ) -> None:
     """Plot left singular vectors (time) of the data matrix.
 
@@ -121,9 +129,13 @@ def plot_lsv_data(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     show_legend: bool
         Whether or not to show the legend. Defaults to True.
+    irf_location:  float | None
+        Location of the ``irf`` by which the time axis will get shifted. If it is None the time
+        axis will not be shifted. Defaults to None.
     """
     add_cycler_if_not_none(ax, cycler)
     dLSV = res.data_left_singular_vectors
+    dLSV = shift_time_axis_by_irf_location(dLSV, irf_location)
     _plot_svd_vectors(dLSV, indices, "left_singular_value_index", ax, show_legend)
     ax.set_title("data. LSV")
     if linlog:
@@ -193,6 +205,7 @@ def plot_lsv_residual(
     linthresh: float = 1,
     cycler: Cycler | None = PlotStyle().cycler,
     show_legend: bool = True,
+    irf_location: float | None = None,
 ) -> None:
     """Plot left singular vectors (time) of the residual matrix.
 
@@ -213,12 +226,16 @@ def plot_lsv_residual(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     show_legend: bool
         Whether or not to show the legend. Defaults to True.
+    irf_location:  float | None
+        Location of the ``irf`` by which the time axis will get shifted. If it is None the time
+        axis will not be shifted. Defaults to None.
     """
     add_cycler_if_not_none(ax, cycler)
     if "weighted_residual_left_singular_vectors" in res:
         rLSV = res.weighted_residual_left_singular_vectors
     else:
         rLSV = res.residual_left_singular_vectors
+    rLSV = shift_time_axis_by_irf_location(rLSV, irf_location)
     _plot_svd_vectors(rLSV, indices, "left_singular_value_index", ax, show_legend)
     ax.set_title("res. LSV")
     if linlog:

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -356,8 +356,8 @@ def get_shifted_traces(
     else:
         raise ValueError(f"No concentrations in result:\n{res}")
 
-    irf_loc = extract_irf_location(res, center_λ, main_irf_nr)
-    return shift_time_axis_by_irf_location(traces, irf_loc)
+    irf_location = extract_irf_location(res, center_λ, main_irf_nr)
+    return shift_time_axis_by_irf_location(traces, irf_location)
 
 
 def add_cycler_if_not_none(axis: Axis, cycler: Cycler | None) -> None:


### PR DESCRIPTION
Since the time axis of the concentration plot is shifted so the location of the IRF is at 0 in overview plots, this makes it harder to compare it the residual/data and LSV plots, especially when using `linlog` axes.
This PR adds the argument `irf_location` to the low level plotting functions which shifts the time axis for those plots the same way the time axis of concentrations is shifted. This shift is automatically applied in `plot_overview` and `plot_simple_overview`.
It also allows for shifting the time axis for the `plot_data_overview` function, which will make it easier to "guesstimate" the initial center location of the IRF, especially when used together with `linlog` scaling.

### Before
![image](https://user-images.githubusercontent.com/9513634/177056115-5bf556c4-2275-4797-bf27-dc96c6d8688d.png)
![image](https://user-images.githubusercontent.com/9513634/177056124-3faf9c86-6ee8-45e1-97f1-726de14abb36.png)


### After
![image](https://user-images.githubusercontent.com/9513634/177055929-4e9c8e37-2ac6-477e-8b53-b416264f69f7.png)
![image](https://user-images.githubusercontent.com/9513634/177056048-687a348b-76da-4462-a33b-0b71b5ad1205.png)
![image](https://user-images.githubusercontent.com/9513634/177056553-26d16fe9-c445-40a4-8b49-a28e41bb021a.png)



### Change summary

- [♻️ Factored out time shifting by irf location into seperate function](https://github.com/glotaran/pyglotaran-extras/commit/3649fc8014e952f4e5db4721d780040fae6a92fc)
- [👌 Added time shifting by irf location tp plot functions](https://github.com/glotaran/pyglotaran-extras/commit/35debe530c619a8929bcc465fa6dcb8b029b9c2c)
- [🩹 Apply linlog scaling to LSV plot in 'plot_data_overview'](https://github.com/glotaran/pyglotaran-extras/pull/99/commits/2c01e723ba9f15bacf5a77946120282381aceb14)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)