### PR TITLE
🩹📚 Fix missing channel flag in conda install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install pyglotaran-extras
 If you want to install it via conda, you can run the following command:
 
 ```console
-conda install pyglotaran-extras
+conda install -c conda-forge pyglotaran-extras
 ```
 
 ### From Source


### PR DESCRIPTION
Specifying the channel flag allows installation with conda even if users don't hate `conda-forge` added to their channels.

### Change summary

- [🩹📚 Fix missing channel flag in conda install guide](https://github.com/glotaran/pyglotaran-extras/commit/465fc57698ba8553574dfde750438da90e8ede06)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 📚 Adds documentation of the feature

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #105 
