### PR TITLE
🩹🚇 Fix 'Test pyglotaran dev' CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,10 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install -U pip wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
       - name: Check out repo

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+(changes-0_7_0)=
+
+## 0.7.0 (Unreleased)
+
+- 🩹🚇 Fix 'Test pyglotaran dev' CI step (#117)
+
 (changes-0_6_0)=
 
 ## 0.6.0 (2022-06-07)

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,11 +2,15 @@ version: 2
 
 formats: all
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
Currently the CI step `Test pyglotaran dev` [is failing](https://github.com/glotaran/pyglotaran-extras/actions/runs/3570554513/jobs/6001697589) because the development version of pyglotaran on main requires python `3.10` and the step is configured to use python `3.8`. In addition, I also added python `3.10` as a version in the CI test matrix and changed the RTD config to build docs on python `3.10`.

### Change summary

- [🩹🚇 Raised python version for glotaran-dev test to 3.10](https://github.com/glotaran/pyglotaran-extras/commit/ab8913abeb6d5cb37d21cf3f3d0c0a77cb7769fd)
- [🚇👌 Added python 3.10 to python versions for unit tests](https://github.com/glotaran/pyglotaran-extras/commit/c2b416a900b5e0f158d6f1ac78c6bc31f2841639)
- [🚇📚 Upgraded readthedocs.yml so RTD builds on python 3.10](https://github.com/glotaran/pyglotaran-extras/commit/bdc727e6bcff3d7078a61ea55c82ea5ca827caf5)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)