### PR TITLE
👌 Add option to deactivate data/residual plotting in overview plots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ## 0.7.0 (Unreleased)
 
 - 🩹🚇 Fix 'Test pyglotaran dev' CI step (#117)
+- 👌 Add option to deactivate data/residual plotting in overview plots (#118)
 
 (changes-0_6_0)=
 

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -104,10 +104,7 @@ def plot_overview(
 
     if res.coords["time"].values.size == 1:
         fig, axes = plot_guidance(res)
-        if figure_only is True:
-            return fig
-        return fig, axes
-
+        return fig if figure_only is True else (fig, axes)
     # Plot dimensions
     M = 4
     N = 3

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -37,7 +37,7 @@ def plot_overview(
     linlog: bool = True,
     linthresh: float = 1,
     linscale: float = 1,
-    show_data: bool = False,
+    show_data: bool | None = False,
     main_irf_nr: int = 0,
     figsize: tuple[int, int] = (18, 16),
     cycler: Cycler | None = PlotStyle().cycler,
@@ -68,8 +68,9 @@ def plot_overview(
         For example, when linscale == 1.0 (the default), the space used for the
         positive and negative halves of the linear range will be equal to one
         decade in the logarithmic range. Defaults to 1.
-    show_data: bool
-        Whether to show the input data or residual. Defaults to False.
+    show_data: bool | None
+        Whether to show the input data or residual. If set to ``None`` the plot is skipped
+        which improves plotting performance for big datasets. Defaults to False.
     main_irf_nr: int
         Index of the main ``irf`` component when using an ``irf``
         parametrized with multiple peaks. Defaults to 0.
@@ -164,6 +165,7 @@ def plot_simple_overview(
     cycler: Cycler | None = PlotStyle().cycler,
     figure_only: bool = True,
     show_irf_dispersion_center: bool = True,
+    show_data: bool | None = False,
 ) -> Figure | tuple[Figure, Axes]:
     """Plot simple overview.
 
@@ -184,6 +186,9 @@ def plot_simple_overview(
     show_irf_dispersion_center: bool
         Whether to show the the IRF dispersion center as overlay on the residual/data plot.
         Defaults to True.
+    show_data: bool | None
+        Whether to show the input data or residual. If set to ``None`` the plot is skipped
+        which improves plotting performance for big datasets. Defaults to False.
 
     Returns
     -------
@@ -210,7 +215,7 @@ def plot_simple_overview(
     plot_residual(
         res,
         axes[0, 2],
-        show_data=True,
+        show_data=show_data,
         show_irf_dispersion_center=show_irf_dispersion_center,
         irf_location=irf_location,
     )

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -21,7 +21,7 @@ def plot_residual(
     ax: Axis,
     linlog: bool = False,
     linthresh: float = 1,
-    show_data: bool = False,
+    show_data: bool | None = False,
     cycler: Cycler | None = PlotStyle().cycler,
     show_irf_dispersion_center: bool = True,
     irf_location: float | None = None,
@@ -39,8 +39,9 @@ def plot_residual(
     linthresh : float
         A single float which defines the range (-x, x), within which the plot is linear.
         This avoids having the plot go to infinity around zero. Defaults to 1.
-    show_data : bool
-        Whether to show the data or the residual. Defaults to False.
+    show_data: bool | None
+        Whether to show the input data or residual. If set to ``None`` the plot is skipped
+        which improves plotting performance for big datasets. Defaults to False.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     show_irf_dispersion_center: bool
@@ -50,6 +51,17 @@ def plot_residual(
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
     """
+    if show_data is None:
+        ax.text(
+            0.5,
+            0.5,
+            "Skipped",
+            horizontalalignment="center",
+            verticalalignment="center",
+            fontsize=24,
+        )
+        return
+
     add_cycler_if_not_none(ax, cycler)
     data = res.data if show_data else res.residual
     data = shift_time_axis_by_irf_location(data, irf_location)

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -67,9 +67,9 @@ def plot_residual(
     data = shift_time_axis_by_irf_location(data, irf_location)
     title = "dataset" if show_data else "residual"
     shape = np.array(data.shape)
-    dims = data.coords.dims
     # Handle different dimensionality of data
     if min(shape) == 1:
+        dims = data.coords.dims
         data.plot.line(x=dims[shape.argmax()], ax=ax)
     elif min(shape) < 5:
         data.plot(x="time", ax=ax)


### PR DESCRIPTION
Especially for big datasets the 2D plots (data/residual) in `plot_overview` or `plot_simple_overview` can take a long time (up to 1 minute). This change adds `None` as a possible value for `show_data` which allows switching off this part of the plot altogether, instead "Skipped" will be written to the middle of the axis (subplot).

The following code will generate the plot below it
```python
from glotaran.testing.simulated_data.sequential_spectral_decay import SCHEME
from glotaran.optimization.optimize import optimize
from pyglotaran_extras import plot_overview

result = optimize(SCHEME)

plot_overview(
    result.data["dataset_1"],
    figure_only=False,
    nr_of_data_svd_vectors=3,
    nr_of_residual_svd_vectors=1,
    show_data=None,
    linlog=True,
    linthresh=50,
)
```
![image](https://user-images.githubusercontent.com/9513634/205308810-47aec26c-b79a-40dc-a294-fc30c3f0ad27.png)


### Change summary

- [👌 Added option to deactivate 2D plotting for performance improvement](https://github.com/glotaran/pyglotaran-extras/commit/ab549144ade54bb5d15db47da6fb0a0ec5d86f2e)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
