### PR TITLE
✨ Add a-matrix inspection function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     rev: v1.4.0
     hooks:
       - id: yesqa
-        additional_dependencies: [flake8-docstrings]
+        additional_dependencies: [flake8-docstrings, darglint==1.8.0]
 
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.2.0

--- a/pyglotaran_extras/inspect/__init__.py
+++ b/pyglotaran_extras/inspect/__init__.py
@@ -1,1 +1,4 @@
 """Module with analysis inspection functionality."""
+from pyglotaran_extras.inspect.a_matrix import show_a_matrixes
+
+__all__ = ["show_a_matrixes"]

--- a/pyglotaran_extras/inspect/__init__.py
+++ b/pyglotaran_extras/inspect/__init__.py
@@ -1,0 +1,1 @@
+"""Module with analysis inspection functionality."""

--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -1,4 +1,4 @@
-"""Quick and dirty implementation to show all a-matrixes of a result."""
+"""Module containing a-matrix render functionality."""
 
 from __future__ import annotations
 

--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -1,0 +1,165 @@
+"""Quick and dirty implementation to show all a-matrixes of a result."""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+from glotaran.utils.ipython import MarkdownStr
+from tabulate import tabulate
+
+from pyglotaran_extras.inspect.utils import pretty_format_numerical
+from pyglotaran_extras.inspect.utils import pretty_format_numerical_iterable
+from pyglotaran_extras.inspect.utils import wrap_in_details_tag
+from pyglotaran_extras.io.utils import result_dataset_mapping
+from pyglotaran_extras.types import ResultLike
+
+
+def a_matrix_to_html_table(
+    a_matrix: xr.DataArray,
+    megacomplex_suffix: str,
+    *,
+    normalize_initial_concentration: bool = False,
+    decimal_places: int = 3,
+) -> str:
+    """Create html multi header table from a-matrix.
+
+    Parameters
+    ----------
+    a_matrix: xr.DataArray
+        DataArray containing the a-matrix values and coordinates.
+    megacomplex_suffix: str
+        Megacomplex suffix used for the a-matrix data variable and coordinate names.
+    normalize_initial_concentration: bool
+        Whether or not to normalize the initial concentration. Defaults to False
+    decimal_places: int
+        Decimal places to display. Defaults to 3
+
+    Returns
+    -------
+    str
+        Multi header htm table representing the a-matrix.
+    """
+    species = a_matrix.coords[f"species_{megacomplex_suffix}"].values
+    # Crete a copy so normalization does not mutate the original values
+    initial_concentration = np.array(
+        a_matrix.coords[f"initial_concentration_{megacomplex_suffix}"].values
+    )
+    lifetime = a_matrix.coords[f"lifetime_{megacomplex_suffix}"].values
+
+    if normalize_initial_concentration is True:
+        initial_concentration /= initial_concentration.sum()
+
+    header = (
+        ["species<br>initial concentration<br>lifetime↓"]
+        + [
+            f"{sp}<br>{pretty_format_numerical(ic,decimal_places)}<br>&nbsp;"
+            for sp, ic in zip(species, initial_concentration)
+        ]
+        + ["Sum"]
+    )
+
+    data = [
+        pretty_format_numerical_iterable(
+            (lifetime, *amps, amps.sum()), decimal_places=decimal_places
+        )
+        for lifetime, amps in zip(lifetime, a_matrix.values)
+    ]
+    data.append(
+        pretty_format_numerical_iterable(
+            ("Sum", *a_matrix.values.sum(axis=0), a_matrix.values.sum()),
+            decimal_places=decimal_places,
+        )
+    )
+
+    return (
+        tabulate(
+            data, headers=header, showindex=False, tablefmt="unsafehtml", disable_numparse=True
+        )
+        .replace(" 0 ", "   ")
+        .replace(" 0<", "  <")
+        .replace(">0 ", ">  ")
+    )
+
+
+def show_a_matrixes(
+    result: ResultLike,
+    *,
+    normalize_initial_concentration: bool = False,
+    decimal_places: int = 3,
+    a_matrix_min_size: int | None = None,
+    expanded_datasets: tuple[str, ...] = (),
+    heading_offset: int = 2,
+) -> MarkdownStr:
+    """Show all a-matrixes of a result grouped by dataset and megacomplex name.
+
+    Each dataset is wrapped in a HTML details tag which is by default collapsed.
+
+    Parameters
+    ----------
+    result: ResultLike
+        Result or result dataset.
+    normalize_initial_concentration: bool
+        Whether or not to normalize the initial concentration. Defaults to False.
+    decimal_places: int
+        Decimal places to display. Defaults to 3.
+    a_matrix_min_size: int
+        Defaults to None.
+    expanded_datasets: tuple[str, ...]
+        Names of dataset to expand the details view for. Defaults to () which means no dataset
+        is expanded.
+    heading_offset: int
+        Number of heading level to offset the headings. Defaults to 2 which means that the
+        first/top most heading is h3.
+
+    Returns
+    -------
+    MarkdownStr
+        Markdown representation of the a-matrixes used in the optimization.
+    """
+    heading_prefix = heading_offset * "#"
+    output_str = f"#{heading_prefix} A-Matrixes\n"
+
+    result_map = result_dataset_mapping(result)
+
+    for dataset_name in result_map:
+
+        a_matrix_names = list(
+            filter(
+                lambda var_name: var_name.startswith("a_matrix_"),
+                result_map[dataset_name].data_vars,
+            )
+        )
+
+        if not a_matrix_names:
+            continue
+
+        details_content = ""
+
+        for a_matrix_name in a_matrix_names:
+
+            mc_suffix = a_matrix_name.replace("a_matrix_", "")
+
+            a_matrix = result_map[dataset_name][a_matrix_name]
+
+            if a_matrix_min_size is not None and max(a_matrix.shape) < a_matrix_min_size:
+                continue
+
+            details_content += f"###{heading_prefix} {mc_suffix}:\n\n"
+
+            details_content += a_matrix_to_html_table(
+                a_matrix,
+                mc_suffix,
+                normalize_initial_concentration=normalize_initial_concentration,
+                decimal_places=decimal_places,
+            )
+
+        if details_content != "":
+
+            output_str += wrap_in_details_tag(
+                details_content,
+                summary_content=dataset_name,
+                summary_heading_level=2 + heading_offset,
+                is_open=dataset_name in expanded_datasets,
+            )
+
+    return MarkdownStr(output_str)

--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -30,14 +30,14 @@ def a_matrix_to_html_table(
     megacomplex_suffix: str
         Megacomplex suffix used for the a-matrix data variable and coordinate names.
     normalize_initial_concentration: bool
-        Whether or not to normalize the initial concentration. Defaults to False
+        Whether or not to normalize the initial concentration. Defaults to False.
     decimal_places: int
-        Decimal places to display. Defaults to 3
+        Decimal places to display. Defaults to 3.
 
     Returns
     -------
     str
-        Multi header htm table representing the a-matrix.
+        Multi header html table representing the a-matrix.
     """
     species = a_matrix.coords[f"species_{megacomplex_suffix}"].values
     # Crete a copy so normalization does not mutate the original values
@@ -105,7 +105,7 @@ def show_a_matrixes(
     a_matrix_min_size: int
         Defaults to None.
     expanded_datasets: tuple[str, ...]
-        Names of dataset to expand the details view for. Defaults to () which means no dataset
+        Names of dataset to expand the details view for. Defaults to empty tuple () which means no dataset
         is expanded.
     heading_offset: int
         Number of heading level to offset the headings. Defaults to 2 which means that the

--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -21,7 +21,7 @@ def a_matrix_to_html_table(
     normalize_initial_concentration: bool = False,
     decimal_places: int = 3,
 ) -> str:
-    """Create html multi header table from a-matrix.
+    """Create HTML multi header table from a-matrix.
 
     Parameters
     ----------
@@ -37,7 +37,7 @@ def a_matrix_to_html_table(
     Returns
     -------
     str
-        Multi header html table representing the a-matrix.
+        Multi header HTML table representing the a-matrix.
     """
     species = a_matrix.coords[f"species_{megacomplex_suffix}"].values
     # Crete a copy so normalization does not mutate the original values
@@ -105,8 +105,8 @@ def show_a_matrixes(
     a_matrix_min_size: int
         Defaults to None.
     expanded_datasets: tuple[str, ...]
-        Names of dataset to expand the details view for. Defaults to empty tuple () which means no dataset
-        is expanded.
+        Names of dataset to expand the details view for. Defaults to empty tuple () which means no
+        dataset is expanded.
     heading_offset: int
         Number of heading level to offset the headings. Defaults to 2 which means that the
         first/top most heading is h3.

--- a/pyglotaran_extras/inspect/utils.py
+++ b/pyglotaran_extras/inspect/utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 
 def wrap_in_details_tag(
     details_content: str,
@@ -43,3 +45,39 @@ def wrap_in_details_tag(
 
     out_str += f"\n{details_content}\n</details>"
     return out_str
+
+
+def pretty_format_numerical(value: float | int, decimal_places: int = 1) -> str:
+    """Format value with with at most ``decimal_places`` decimal places.
+
+    Used to format values like the t-value.
+
+    TODO: remove after raise pyglotaran dependency to 0.7.0
+    Forward port of https://github.com/glotaran/pyglotaran/pull/1192
+
+    Parameters
+    ----------
+    value: float | int
+        Numerical value to format.
+    decimal_places: int
+        Decimal places to display. Defaults to 1
+
+    Returns
+    -------
+    str
+        Pretty formatted version of the value.
+    """
+    # Bool returned by numpy do not support the ``is`` comparison (not same singleton as in python)
+    # Ref: https://stackoverflow.com/a/37744300/3990615
+    if not np.isfinite(value):
+        return str(value)
+    if abs(value - int(value)) <= np.finfo(np.float64).eps:
+        return str(int(value))
+    abs_value = abs(value)
+    if abs_value < 10 ** (-decimal_places):
+        format_instruction = f".{decimal_places}e"
+    elif abs_value < 10 ** (decimal_places):
+        format_instruction = f".{decimal_places}f"
+    else:
+        format_instruction = ".0f"
+    return f"{value:{format_instruction}}"

--- a/pyglotaran_extras/inspect/utils.py
+++ b/pyglotaran_extras/inspect/utils.py
@@ -1,0 +1,45 @@
+"""Inspection utility module."""
+
+from __future__ import annotations
+
+
+def wrap_in_details_tag(
+    details_content: str,
+    *,
+    summary_content: str | None = None,
+    summary_heading_level: int | None = None,
+    is_open: bool = False,
+) -> str:
+    """Wrap ``details_content`` in a html details tag and add summary if ``summary_content`` set.
+
+    Parameters
+    ----------
+    details_content: str
+        Markdown string that should be displayed when the details are expanded.
+    summary_content: str | None
+        Summary test that should be displayed. Defaults to None so the summary is ``Details``.
+    summary_heading_level: int | None
+        Level of the heading wrapping the ``summary`` if it is not None. Defaults to None
+    is_open: bool
+        Whether or not the details tag should be initially opened. Defaults to False
+
+    Returns
+    -------
+    str
+    """
+    out_str = f'\n<details {"open" if is_open else ""}>\n'
+    if summary_content is not None:
+        out_str += "<summary>\n"
+        if summary_heading_level is None:
+            out_str += f"{summary_content}\n"
+        else:
+            # Ref.:
+            # https://css-tricks.com/two-issues-styling-the-details-element-and-how-to-solve-them/
+            out_str += f'<h{summary_heading_level} style="display:inline;">\n'
+            out_str += f"{summary_content}\n"
+            out_str += f"</h{summary_heading_level}>\n"
+
+        out_str += "</summary>\n"
+
+    out_str += f"\n{details_content}\n</details>"
+    return out_str

--- a/pyglotaran_extras/inspect/utils.py
+++ b/pyglotaran_extras/inspect/utils.py
@@ -24,9 +24,9 @@ def wrap_in_details_tag(
     summary_content: str | None
         Summary test that should be displayed. Defaults to None so the summary is ``Details``.
     summary_heading_level: int | None
-        Level of the heading wrapping the ``summary`` if it is not None. Defaults to None
+        Level of the heading wrapping the ``summary`` if it is not None. Defaults to None.
     is_open: bool
-        Whether or not the details tag should be initially opened. Defaults to False
+        Whether or not the details tag should be initially opened. Defaults to False.
 
     Returns
     -------
@@ -63,7 +63,7 @@ def pretty_format_numerical(value: float | int, decimal_places: int = 1) -> str:
     value: float | int
         Numerical value to format.
     decimal_places: int
-        Decimal places to display. Defaults to 1
+        Decimal places to display. Defaults to 1.
 
     Returns
     -------
@@ -97,7 +97,7 @@ def pretty_format_numerical_iterable(
         Values that should be formatted.
     decimal_places: int | None
         Number of decimal places a value should have, if None the original value will be used.
-        Defaults to 3
+        Defaults to 3.
 
     See Also
     --------

--- a/pyglotaran_extras/inspect/utils.py
+++ b/pyglotaran_extras/inspect/utils.py
@@ -46,7 +46,7 @@ def wrap_in_details_tag(
 
         out_str += "</summary>\n"
 
-    out_str += f"\n{details_content}\n</details>"
+    out_str += f"\n{details_content}\n<br>\n</details>"
     return out_str
 
 

--- a/pyglotaran_extras/inspect/utils.py
+++ b/pyglotaran_extras/inspect/utils.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from collections.abc import Iterable
+
 import numpy as np
 
 
@@ -81,3 +84,32 @@ def pretty_format_numerical(value: float | int, decimal_places: int = 1) -> str:
     else:
         format_instruction = ".0f"
     return f"{value:{format_instruction}}"
+
+
+def pretty_format_numerical_iterable(
+    input_values: Iterable[str | float], decimal_places: int | None = 3
+) -> Generator[str | float, None, None]:
+    """Pretty format numerical values in an iterable of numerical values or strings.
+
+    Parameters
+    ----------
+    input_values: Iterable[str  |  float]
+        Values that should be formatted.
+    decimal_places: int | None
+        Number of decimal places a value should have, if None the original value will be used.
+        Defaults to 3
+
+    See Also
+    --------
+    pretty_format_numerical
+
+    Yields
+    ------
+    str | float
+        Formatted string or initial value if ``decimal_places`` is None.
+    """
+    for val in input_values:
+        if decimal_places is None or isinstance(val, str):
+            yield val
+        else:
+            yield pretty_format_numerical(val, decimal_places=decimal_places)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@
 
 cycler==0.11.0
 matplotlib==3.6.2
-numpy==1.23.4
+numpy==1.22.4
 pyglotaran==0.6.0
 tabulate==0.9.0
 xarray==2022.11.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,11 @@
 # Runtime dependencies
 
+cycler==0.11.0
 matplotlib==3.6.2
+numpy==1.23.4
 pyglotaran==0.6.0
+tabulate==0.9.0
+xarray==2022.11.0
 
 # Documentation dependencies
 -r docs/requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,11 @@ project_urls =
 [options]
 packages = find:
 install_requires =
+    cycler>=0.10
     matplotlib>=3.3.0
-    pyglotaran>=0.5.1
+    numpy>=1.21.2,<1.24
+    pyglotaran>=0.6
+    tabulate>=0.8.9
     xarray>=2022.3.0
 python_requires = >=3.8,<3.11
 zip_safe = True

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+TEST_DATA = Path(__file__).parent / "data"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,27 @@
+from dataclasses import replace
+
+import pytest
+from glotaran.optimization.optimize import optimize
+from glotaran.testing.simulated_data.parallel_spectral_decay import SCHEME as scheme_par
+from glotaran.testing.simulated_data.sequential_spectral_decay import SCHEME as scheme_seq
+
 from pyglotaran_extras.io.setup_case_study import get_script_dir
 
 
 def wrapped_get_script_dir():
     """Testfunction for calls to get_script_dir used inside of other functions."""
     return get_script_dir(nesting=1)
+
+
+@pytest.fixture(scope="session")
+def result_parallel_spectral_decay():
+    """Test result from ``glotaran.testing.simulated_data.parallel_spectral_decay``."""
+    scheme = replace(scheme_par, maximum_number_function_evaluations=1)
+    yield optimize(scheme)
+
+
+@pytest.fixture(scope="session")
+def result_sequential_spectral_decay():
+    """Test result from ``glotaran.testing.simulated_data.sequential_spectral_decay``."""
+    scheme = replace(scheme_seq, maximum_number_function_evaluations=1)
+    yield optimize(scheme)

--- a/tests/data/a_matrix/a_matrix_to_html_table_decimal_2.md
+++ b/tests/data/a_matrix/a_matrix_to_html_table_decimal_2.md
@@ -1,0 +1,11 @@
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>1<br>&nbsp;  </th><th>species_3<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.33                      </td><td>                          </td><td>                          </td><td>0.33 </td></tr>
+<tr><td>3.33                                           </td><td>                          </td><td>0.33                      </td><td>                          </td><td>0.33 </td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>0.33                      </td><td>0.33 </td></tr>
+<tr><td>Sum                                            </td><td>0.33                      </td><td>0.33                      </td><td>0.33                      </td><td>1    </td></tr>
+</tbody>
+</table>

--- a/tests/data/a_matrix/a_matrix_to_html_table_default.md
+++ b/tests/data/a_matrix/a_matrix_to_html_table_default.md
@@ -1,0 +1,11 @@
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>1<br>&nbsp;  </th><th>species_3<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.333                     </td><td>                          </td><td>                          </td><td>0.333</td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>0.333                     </td><td>                          </td><td>0.333</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>0.333                     </td><td>0.333</td></tr>
+<tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
+</tbody>
+</table>

--- a/tests/data/a_matrix/a_matrix_to_html_table_normalized.md
+++ b/tests/data/a_matrix/a_matrix_to_html_table_normalized.md
@@ -1,0 +1,11 @@
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>0.333<br>&nbsp;  </th><th>species_2<br>0.333<br>&nbsp;  </th><th>species_3<br>0.333<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.333                         </td><td>                              </td><td>                              </td><td>0.333</td></tr>
+<tr><td>3.333                                          </td><td>                              </td><td>0.333                         </td><td>                              </td><td>0.333</td></tr>
+<tr><td>10                                             </td><td>                              </td><td>                              </td><td>0.333                         </td><td>0.333</td></tr>
+<tr><td>Sum                                            </td><td>0.333                         </td><td>0.333                         </td><td>0.333                         </td><td>1    </td></tr>
+</tbody>
+</table>

--- a/tests/data/a_matrix/show_a_matrixes_decimal_2.md
+++ b/tests/data/a_matrix/show_a_matrixes_decimal_2.md
@@ -1,0 +1,63 @@
+### A-Matrixes
+
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_1
+</h4>
+</summary>
+
+##### megacomplex_parallel_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>1<br>&nbsp;  </th><th>species_3<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.33                      </td><td>                          </td><td>                          </td><td>0.33 </td></tr>
+<tr><td>3.33                                           </td><td>                          </td><td>0.33                      </td><td>                          </td><td>0.33 </td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>0.33                      </td><td>0.33 </td></tr>
+<tr><td>Sum                                            </td><td>0.33                      </td><td>0.33                      </td><td>0.33                      </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_2
+</h4>
+</summary>
+
+##### megacomplex_sequential_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>0<br>&nbsp;  </th><th>species_3<br>0<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>-2.50                     </td><td>1.87                      </td><td>0.37 </td></tr>
+<tr><td>3.33                                           </td><td>                          </td><td>2.50                      </td><td>-3.75                     </td><td>-1.25</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>1.88                      </td><td>1.88 </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.44e-16                 </td><td>1.00 </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h4 style="display:inline;">
+single_entry_a_matrix
+</h4>
+</summary>
+
+##### single_entry:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>1    </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>

--- a/tests/data/a_matrix/show_a_matrixes_decimal_2.md
+++ b/tests/data/a_matrix/show_a_matrixes_decimal_2.md
@@ -20,6 +20,7 @@ dataset_1
 <tr><td>Sum                                            </td><td>0.33                      </td><td>0.33                      </td><td>0.33                      </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -41,6 +42,7 @@ dataset_2
 <tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.44e-16                 </td><td>1.00 </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -60,4 +62,5 @@ single_entry_a_matrix
 <tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>

--- a/tests/data/a_matrix/show_a_matrixes_default.md
+++ b/tests/data/a_matrix/show_a_matrixes_default.md
@@ -1,0 +1,63 @@
+### A-Matrixes
+
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_1
+</h4>
+</summary>
+
+##### megacomplex_parallel_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>1<br>&nbsp;  </th><th>species_3<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.333                     </td><td>                          </td><td>                          </td><td>0.333</td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>0.333                     </td><td>                          </td><td>0.333</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>0.333                     </td><td>0.333</td></tr>
+<tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_2
+</h4>
+</summary>
+
+##### megacomplex_sequential_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>0<br>&nbsp;  </th><th>species_3<br>0<br>&nbsp;  </th><th>Sum   </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>-2.500                    </td><td>1.875                     </td><td>0.375 </td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>2.500                     </td><td>-3.750                    </td><td>-1.250</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>1.875                     </td><td>1.875 </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h4 style="display:inline;">
+single_entry_a_matrix
+</h4>
+</summary>
+
+##### single_entry:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>1    </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>

--- a/tests/data/a_matrix/show_a_matrixes_default.md
+++ b/tests/data/a_matrix/show_a_matrixes_default.md
@@ -20,6 +20,7 @@ dataset_1
 <tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -41,6 +42,7 @@ dataset_2
 <tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -60,4 +62,5 @@ single_entry_a_matrix
 <tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>

--- a/tests/data/a_matrix/show_a_matrixes_expanded_dataset_2.md
+++ b/tests/data/a_matrix/show_a_matrixes_expanded_dataset_2.md
@@ -20,6 +20,7 @@ dataset_1
 <tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details open>
 <summary>
@@ -41,6 +42,7 @@ dataset_2
 <tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -60,4 +62,5 @@ single_entry_a_matrix
 <tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>

--- a/tests/data/a_matrix/show_a_matrixes_expanded_dataset_2.md
+++ b/tests/data/a_matrix/show_a_matrixes_expanded_dataset_2.md
@@ -1,0 +1,63 @@
+### A-Matrixes
+
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_1
+</h4>
+</summary>
+
+##### megacomplex_parallel_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>1<br>&nbsp;  </th><th>species_3<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.333                     </td><td>                          </td><td>                          </td><td>0.333</td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>0.333                     </td><td>                          </td><td>0.333</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>0.333                     </td><td>0.333</td></tr>
+<tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>
+<details open>
+<summary>
+<h4 style="display:inline;">
+dataset_2
+</h4>
+</summary>
+
+##### megacomplex_sequential_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>0<br>&nbsp;  </th><th>species_3<br>0<br>&nbsp;  </th><th>Sum   </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>-2.500                    </td><td>1.875                     </td><td>0.375 </td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>2.500                     </td><td>-3.750                    </td><td>-1.250</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>1.875                     </td><td>1.875 </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h4 style="display:inline;">
+single_entry_a_matrix
+</h4>
+</summary>
+
+##### single_entry:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>1    </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>

--- a/tests/data/a_matrix/show_a_matrixes_heading_offset_0.md
+++ b/tests/data/a_matrix/show_a_matrixes_heading_offset_0.md
@@ -1,0 +1,63 @@
+# A-Matrixes
+
+<details >
+<summary>
+<h2 style="display:inline;">
+dataset_1
+</h2>
+</summary>
+
+### megacomplex_parallel_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>1<br>&nbsp;  </th><th>species_3<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.333                     </td><td>                          </td><td>                          </td><td>0.333</td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>0.333                     </td><td>                          </td><td>0.333</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>0.333                     </td><td>0.333</td></tr>
+<tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h2 style="display:inline;">
+dataset_2
+</h2>
+</summary>
+
+### megacomplex_sequential_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>0<br>&nbsp;  </th><th>species_3<br>0<br>&nbsp;  </th><th>Sum   </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>-2.500                    </td><td>1.875                     </td><td>0.375 </td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>2.500                     </td><td>-3.750                    </td><td>-1.250</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>1.875                     </td><td>1.875 </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h2 style="display:inline;">
+single_entry_a_matrix
+</h2>
+</summary>
+
+### single_entry:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>1    </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>

--- a/tests/data/a_matrix/show_a_matrixes_heading_offset_0.md
+++ b/tests/data/a_matrix/show_a_matrixes_heading_offset_0.md
@@ -20,6 +20,7 @@ dataset_1
 <tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -41,6 +42,7 @@ dataset_2
 <tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -60,4 +62,5 @@ single_entry_a_matrix
 <tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>

--- a/tests/data/a_matrix/show_a_matrixes_min_size_2.md
+++ b/tests/data/a_matrix/show_a_matrixes_min_size_2.md
@@ -20,6 +20,7 @@ dataset_1
 <tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -41,4 +42,5 @@ dataset_2
 <tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
 </tbody>
 </table>
+<br>
 </details>

--- a/tests/data/a_matrix/show_a_matrixes_min_size_2.md
+++ b/tests/data/a_matrix/show_a_matrixes_min_size_2.md
@@ -1,0 +1,44 @@
+### A-Matrixes
+
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_1
+</h4>
+</summary>
+
+##### megacomplex_parallel_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>1<br>&nbsp;  </th><th>species_3<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.333                     </td><td>                          </td><td>                          </td><td>0.333</td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>0.333                     </td><td>                          </td><td>0.333</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>0.333                     </td><td>0.333</td></tr>
+<tr><td>Sum                                            </td><td>0.333                     </td><td>0.333                     </td><td>0.333                     </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_2
+</h4>
+</summary>
+
+##### megacomplex_sequential_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>0<br>&nbsp;  </th><th>species_3<br>0<br>&nbsp;  </th><th>Sum   </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>-2.500                    </td><td>1.875                     </td><td>0.375 </td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>2.500                     </td><td>-3.750                    </td><td>-1.250</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>1.875                     </td><td>1.875 </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
+</tbody>
+</table>
+</details>

--- a/tests/data/a_matrix/show_a_matrixes_normalized.md
+++ b/tests/data/a_matrix/show_a_matrixes_normalized.md
@@ -20,6 +20,7 @@ dataset_1
 <tr><td>Sum                                            </td><td>0.333                         </td><td>0.333                         </td><td>0.333                         </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -41,6 +42,7 @@ dataset_2
 <tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
 </tbody>
 </table>
+<br>
 </details>
 <details >
 <summary>
@@ -60,4 +62,5 @@ single_entry_a_matrix
 <tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
 </tbody>
 </table>
+<br>
 </details>

--- a/tests/data/a_matrix/show_a_matrixes_normalized.md
+++ b/tests/data/a_matrix/show_a_matrixes_normalized.md
@@ -1,0 +1,63 @@
+### A-Matrixes
+
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_1
+</h4>
+</summary>
+
+##### megacomplex_parallel_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>0.333<br>&nbsp;  </th><th>species_2<br>0.333<br>&nbsp;  </th><th>species_3<br>0.333<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>0.333                         </td><td>                              </td><td>                              </td><td>0.333</td></tr>
+<tr><td>3.333                                          </td><td>                              </td><td>0.333                         </td><td>                              </td><td>0.333</td></tr>
+<tr><td>10                                             </td><td>                              </td><td>                              </td><td>0.333                         </td><td>0.333</td></tr>
+<tr><td>Sum                                            </td><td>0.333                         </td><td>0.333                         </td><td>0.333                         </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset_2
+</h4>
+</summary>
+
+##### megacomplex_sequential_decay:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>species_2<br>0<br>&nbsp;  </th><th>species_3<br>0<br>&nbsp;  </th><th>Sum   </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>-2.500                    </td><td>1.875                     </td><td>0.375 </td></tr>
+<tr><td>3.333                                          </td><td>                          </td><td>2.500                     </td><td>-3.750                    </td><td>-1.250</td></tr>
+<tr><td>10                                             </td><td>                          </td><td>                          </td><td>1.875                     </td><td>1.875 </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>                          </td><td>-4.441e-16                </td><td>1.000 </td></tr>
+</tbody>
+</table>
+</details>
+<details >
+<summary>
+<h4 style="display:inline;">
+single_entry_a_matrix
+</h4>
+</summary>
+
+##### single_entry:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>1    </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
+</tbody>
+</table>
+</details>

--- a/tests/inspect/__init__.py
+++ b/tests/inspect/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``pyglotaran_extras.inspect``."""

--- a/tests/inspect/test_a_matrix.py
+++ b/tests/inspect/test_a_matrix.py
@@ -1,4 +1,5 @@
 """Tests for ``pyglotaran_extras.inspect.a_matrix``."""
+from __future__ import annotations
 
 from typing import Any
 

--- a/tests/inspect/test_a_matrix.py
+++ b/tests/inspect/test_a_matrix.py
@@ -24,9 +24,9 @@ def test_a_matrix_to_html_table(
     result_parallel_spectral_decay: Result, kwargs: dict[str, Any], compare_file_suffix: str
 ):
     """Same string as in test file except final newline added by editors."""
-    expected = (
-        TEST_DATA / f"a_matrix/a_matrix_to_html_table_{compare_file_suffix}.md"
-    ).read_text()
+    expected = (TEST_DATA / f"a_matrix/a_matrix_to_html_table_{compare_file_suffix}.md").read_text(
+        encoding="utf8"
+    )
     assert a_matrix_to_html_table(
         result_parallel_spectral_decay.data["dataset_1"].a_matrix_megacomplex_parallel_decay,
         "megacomplex_parallel_decay",
@@ -51,7 +51,9 @@ def test_show_a_matrixes(
     compare_file_suffix: str,
 ):
     """Same string as in test file except final newline added by editors."""
-    expected = (TEST_DATA / f"a_matrix/show_a_matrixes_{compare_file_suffix}.md").read_text()
+    expected = (TEST_DATA / f"a_matrix/show_a_matrixes_{compare_file_suffix}.md").read_text(
+        encoding="utf8"
+    )
 
     result = result_parallel_spectral_decay
     result.data["dataset_2"] = result_sequential_spectral_decay.data["dataset_1"]

--- a/tests/inspect/test_a_matrix.py
+++ b/tests/inspect/test_a_matrix.py
@@ -1,0 +1,69 @@
+"""Tests for ``pyglotaran_extras.inspect.a_matrix``."""
+
+from typing import Any
+
+import pytest
+import xarray as xr
+from glotaran.project import Result
+from tests import TEST_DATA
+
+from pyglotaran_extras.inspect.a_matrix import a_matrix_to_html_table
+from pyglotaran_extras.inspect.a_matrix import show_a_matrixes
+
+
+@pytest.mark.parametrize(
+    "kwargs, compare_file_suffix",
+    (
+        ({}, "default"),
+        ({"normalize_initial_concentration": True}, "normalized"),
+        ({"decimal_places": 2}, "decimal_2"),
+    ),
+)
+def test_a_matrix_to_html_table(
+    result_parallel_spectral_decay: Result, kwargs: dict[str, Any], compare_file_suffix: str
+):
+    """Same string as in test file except final newline added by editors."""
+    expected = (
+        TEST_DATA / f"a_matrix/a_matrix_to_html_table_{compare_file_suffix}.md"
+    ).read_text()
+    assert a_matrix_to_html_table(
+        result_parallel_spectral_decay.data["dataset_1"].a_matrix_megacomplex_parallel_decay,
+        "megacomplex_parallel_decay",
+        **kwargs,
+    ) == expected.rstrip("\n")
+
+
+@pytest.mark.parametrize(
+    "kwargs, compare_file_suffix",
+    (
+        ({}, "default"),
+        ({"normalize_initial_concentration": True}, "normalized"),
+        ({"decimal_places": 2}, "decimal_2"),
+        ({"expanded_datasets": ("dataset_2",)}, "expanded_dataset_2"),
+        ({"heading_offset": 0}, "heading_offset_0"),
+    ),
+)
+def test_show_a_matrixes(
+    result_parallel_spectral_decay: Result,
+    result_sequential_spectral_decay: Result,
+    kwargs: dict[str, Any],
+    compare_file_suffix: str,
+):
+    """Same string as in test file except final newline added by editors."""
+    expected = (TEST_DATA / f"a_matrix/show_a_matrixes_{compare_file_suffix}.md").read_text()
+
+    result = result_parallel_spectral_decay
+    result.data["dataset_2"] = result_sequential_spectral_decay.data["dataset_1"]
+    # dummy data for filtering based on a-matrix size
+    single_entry_data = result_sequential_spectral_decay.data[
+        "dataset_1"
+    ].a_matrix_megacomplex_sequential_decay[:1, :1]
+    single_entry_data = single_entry_data.rename(
+        {
+            name: name.replace("megacomplex_sequential_decay", "single_entry")
+            for name in single_entry_data.coords
+        }
+    )
+    result.data["single_entry_a_matrix"] = xr.Dataset({"a_matrix_single_entry": single_entry_data})
+
+    assert str(show_a_matrixes(result, **kwargs)) == expected.rstrip("\n")

--- a/tests/inspect/test_utils.py
+++ b/tests/inspect/test_utils.py
@@ -1,12 +1,14 @@
 """Tests for ``pyglotaran_extras.inspect.utils``."""
 from __future__ import annotations
 
+from collections.abc import Iterable
 from textwrap import dedent
 
 import numpy as np
 import pytest
 
 from pyglotaran_extras.inspect.utils import pretty_format_numerical
+from pyglotaran_extras.inspect.utils import pretty_format_numerical_iterable
 from pyglotaran_extras.inspect.utils import wrap_in_details_tag
 
 
@@ -144,3 +146,16 @@ def test_pretty_format_numerical(value: float, decimal_places: int, expected: st
     result = pretty_format_numerical(value, decimal_places)
 
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "decimal_places, expected",
+    (
+        (None, ["Foo", 1, 0.009, -1.0000000000000002, np.nan, np.inf]),
+        (2, ["Foo", "1", "9.00e-03", "-1", "nan", "inf"]),
+    ),
+)
+def test_pretty_format_numerical_iterable(decimal_places: int, expected: Iterable[str | float]):
+    """Values correct formatted"""
+    values = ("Foo", 1, 0.009, -1.0000000000000002, np.nan, np.inf)
+    assert list(pretty_format_numerical_iterable(values, decimal_places)) == expected

--- a/tests/inspect/test_utils.py
+++ b/tests/inspect/test_utils.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 from textwrap import dedent
 
+import numpy as np
 import pytest
 
+from pyglotaran_extras.inspect.utils import pretty_format_numerical
 from pyglotaran_extras.inspect.utils import wrap_in_details_tag
 
 
@@ -108,3 +110,37 @@ def test_wrap_in_details_tag(
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    "value, decimal_places, expected",
+    (
+        (0.00000001, 1, "1.0e-08"),
+        (-0.00000001, 1, "-1.0e-08"),
+        (0.1, 1, "0.1"),
+        (1.7, 1, "1.7"),
+        (10, 1, "10"),
+        (1.0000000000000002, 10, "1"),
+        (-1.0000000000000002, 10, "-1"),
+        (10, 10, "10"),
+        (-10, 10, "-10"),
+        (0.00000001, 8, "0.00000001"),
+        (-0.00000001, 8, "-0.00000001"),
+        (0.009, 2, "9.00e-03"),
+        (-0.009, 2, "-9.00e-03"),
+        (0.01, 2, "0.01"),
+        (12.3, 2, "12.30"),
+        (np.nan, 1, "nan"),
+        (np.inf, 1, "inf"),
+        (-np.inf, 1, "-inf"),
+    ),
+)
+def test_pretty_format_numerical(value: float, decimal_places: int, expected: str):
+    """Pretty format values depending on decimal_places to show.
+
+    TODO: remove after raise pyglotaran dependency to 0.7.0
+    Forward port of https://github.com/glotaran/pyglotaran/pull/1192 tests
+    """
+    result = pretty_format_numerical(value, decimal_places)
+
+    assert result == expected

--- a/tests/inspect/test_utils.py
+++ b/tests/inspect/test_utils.py
@@ -25,6 +25,7 @@ from pyglotaran_extras.inspect.utils import wrap_in_details_tag
                 <details >
 
                 FOO
+                <br>
                 </details>"""
             ),
             id="defaults",
@@ -39,6 +40,7 @@ from pyglotaran_extras.inspect.utils import wrap_in_details_tag
                 <details >
 
                 FOO
+                <br>
                 </details>"""
             ),
             id="heading no summary",
@@ -53,6 +55,7 @@ from pyglotaran_extras.inspect.utils import wrap_in_details_tag
                 <details open>
 
                 FOO
+                <br>
                 </details>"""
             ),
             id="defaults open details",
@@ -70,6 +73,7 @@ from pyglotaran_extras.inspect.utils import wrap_in_details_tag
                 </summary>
 
                 FOO
+                <br>
                 </details>"""
             ),
             id="defaults with simple summary",
@@ -89,6 +93,7 @@ from pyglotaran_extras.inspect.utils import wrap_in_details_tag
                 </summary>
 
                 FOO
+                <br>
                 </details>"""
             ),
             id="defaults with heading summary",

--- a/tests/inspect/test_utils.py
+++ b/tests/inspect/test_utils.py
@@ -1,0 +1,110 @@
+"""Tests for ``pyglotaran_extras.inspect.utils``."""
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pyglotaran_extras.inspect.utils import wrap_in_details_tag
+
+
+@pytest.mark.parametrize(
+    "details_content, summary_content, summary_heading_level,is_open,expected",
+    (
+        pytest.param(
+            "FOO",
+            None,
+            None,
+            False,
+            dedent(
+                """
+                <details >
+
+                FOO
+                </details>"""
+            ),
+            id="defaults",
+        ),
+        pytest.param(
+            "FOO",
+            None,
+            5,
+            False,
+            dedent(
+                """
+                <details >
+
+                FOO
+                </details>"""
+            ),
+            id="heading no summary",
+        ),
+        pytest.param(
+            "FOO",
+            None,
+            None,
+            True,
+            dedent(
+                """
+                <details open>
+
+                FOO
+                </details>"""
+            ),
+            id="defaults open details",
+        ),
+        pytest.param(
+            "FOO",
+            "Bar",
+            None,
+            False,
+            dedent(
+                """
+                <details >
+                <summary>
+                Bar
+                </summary>
+
+                FOO
+                </details>"""
+            ),
+            id="defaults with simple summary",
+        ),
+        pytest.param(
+            "FOO",
+            "Bar",
+            5,
+            False,
+            dedent(
+                """
+                <details >
+                <summary>
+                <h5 style="display:inline;">
+                Bar
+                </h5>
+                </summary>
+
+                FOO
+                </details>"""
+            ),
+            id="defaults with heading summary",
+        ),
+    ),
+)
+def test_wrap_in_details_tag(
+    details_content: str,
+    summary_content: str | None,
+    summary_heading_level: int | None,
+    is_open: bool,
+    expected: str,
+):
+    """Correct details."""
+    assert (
+        wrap_in_details_tag(
+            details_content,
+            summary_content=summary_content,
+            summary_heading_level=summary_heading_level,
+            is_open=is_open,
+        )
+        == expected
+    )


### PR DESCRIPTION
This change adds a new sub package for inspection functions (`pyglotaran_extras.inspect`) and the `show_a_matrixes` function to render all a-matrixes in a `ResultLike` optimization result.
The rendered matrixes are wrapped in a html details tag per dataset, which is collapsed by default.
Inside the details tag, the matrixes are placed under a heading with the corresponding megacomplex name.

Here is an example of what output looks like, for more examples have a look at the markdown preview of the [added unit test data](https://github.com/s-weigand/pyglotaran-extras/tree/show-a-matrix/tests/data/a_matrix):
![image](https://user-images.githubusercontent.com/9513634/210086969-84a1bfc3-15c8-49c5-a13f-65f3c3d66cba.png)



### Change summary

- :sparkles: [ Added wrap_in_details_tag utility function](https://github.com/glotaran/pyglotaran-extras/commit/b8a3b6f6da3309ed2c30c6dac5025a805bdf49bf)
- :construction: [ Made implicit dependencies explicit](https://github.com/glotaran/pyglotaran-extras/commit/ae9b67e3bb6dad912e7cf877a63bac17d63f0ebe)
- :sparkles: [ Forward ported fixed pretty_format_numerical from pyglotaran main](https://github.com/glotaran/pyglotaran-extras/commit/b51c45f46aa5bf6a19615598be648ca8ca10f04e)
- :wrench: [ Added darglint as yesqa dependency](https://github.com/glotaran/pyglotaran-extras/commit/34c663368b8077189972ca3f51dbc48d1f5f9eaf)
- :sparkles: [ Added pretty_format_numerical_iterable helper function](https://github.com/glotaran/pyglotaran-extras/commit/ff93616300a82377798e39e6eac0fd9034294b8f)
- :sparkles: [ Added show a-matrix functions and tests](https://github.com/glotaran/pyglotaran-extras/commit/04a864484982c134093f8d7c47627f1d012474d7)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
