### PR TITLE
✨ Add show_zero_line option to plot_overview and plot_fitted_traces

### DIFF
--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -47,6 +47,7 @@ def plot_overview(
     show_data_svd_legend: bool = True,
     show_residual_svd_legend: bool = True,
     show_irf_dispersion_center: bool = True,
+    show_zero_line: bool = True,
 ) -> Figure | tuple[Figure, Axes]:
     """Plot overview of the optimization result.
 
@@ -93,6 +94,9 @@ def plot_overview(
     show_irf_dispersion_center: bool
         Whether to show the the IRF dispersion center as overlay on the residual/data plot.
         Defaults to True.
+    show_zero_line: bool
+        Whether or not to add a horizontal line at zero to the plots of the spectra.
+        Defaults to True.
 
     Returns
     -------
@@ -126,7 +130,7 @@ def plot_overview(
         main_irf_nr=main_irf_nr,
         cycler=cycler,
     )
-    plot_spectra(res, axes[0:2, 1:3], cycler=cycler)
+    plot_spectra(res, axes[0:2, 1:3], cycler=cycler, show_zero_line=show_zero_line)
     plot_svd(
         res,
         axes[2:4, 0:3],

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -15,7 +15,12 @@ if TYPE_CHECKING:
     from matplotlib.pyplot import Axes
 
 
-def plot_spectra(res: xr.Dataset, axes: Axes, cycler: Cycler | None = PlotStyle().cycler) -> None:
+def plot_spectra(
+    res: xr.Dataset,
+    axes: Axes,
+    cycler: Cycler | None = PlotStyle().cycler,
+    show_zero_line: bool = True,
+) -> None:
     """Plot spectra such as SAS and DAS as well as their normalize version on ``axes``.
 
     Parameters
@@ -26,15 +31,21 @@ def plot_spectra(res: xr.Dataset, axes: Axes, cycler: Cycler | None = PlotStyle(
         Axes to plot the spectra on (needs to be at least 2x2).
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
+    show_zero_line: bool
+        Whether or not to add a horizontal line at zero. Defaults to True.
     """
-    plot_sas(res, axes[0, 0], cycler=cycler)
-    plot_das(res, axes[0, 1], cycler=cycler)
-    plot_norm_sas(res, axes[1, 0], cycler=cycler)
-    plot_norm_das(res, axes[1, 1], cycler=cycler)
+    plot_sas(res, axes[0, 0], cycler=cycler, show_zero_line=show_zero_line)
+    plot_das(res, axes[0, 1], cycler=cycler, show_zero_line=show_zero_line)
+    plot_norm_sas(res, axes[1, 0], cycler=cycler, show_zero_line=show_zero_line)
+    plot_norm_das(res, axes[1, 1], cycler=cycler, show_zero_line=show_zero_line)
 
 
 def plot_sas(
-    res: xr.Dataset, ax: Axis, title: str = "SAS", cycler: Cycler | None = PlotStyle().cycler
+    res: xr.Dataset,
+    ax: Axis,
+    title: str = "SAS",
+    cycler: Cycler | None = PlotStyle().cycler,
+    show_zero_line: bool = True,
 ) -> None:
     """Plot SAS (Species Associated Spectra) on ``ax``.
 
@@ -48,6 +59,8 @@ def plot_sas(
         Title of the plot. Defaults to "SAS".
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
+    show_zero_line: bool
+        Whether or not to add a horizontal line at zero. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
     keys = [
@@ -58,10 +71,16 @@ def plot_sas(
         sas.plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()
+    if show_zero_line is True:
+        ax.axhline(0, color="k", linewidth=1)
 
 
 def plot_norm_sas(
-    res: xr.Dataset, ax: Axis, title: str = "norm SAS", cycler: Cycler | None = PlotStyle().cycler
+    res: xr.Dataset,
+    ax: Axis,
+    title: str = "norm SAS",
+    cycler: Cycler | None = PlotStyle().cycler,
+    show_zero_line: bool = True,
 ) -> None:
     """Plot normalized SAS (Species Associated Spectra) on ``ax``.
 
@@ -75,6 +94,8 @@ def plot_norm_sas(
         Title of the plot. Defaults to "norm SAS".
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
+    show_zero_line: bool
+        Whether or not to add a horizontal line at zero. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
     keys = [
@@ -86,10 +107,16 @@ def plot_norm_sas(
         (sas / np.abs(sas).max(dim="spectral")).plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()
+    if show_zero_line is True:
+        ax.axhline(0, color="k", linewidth=1)
 
 
 def plot_das(
-    res: xr.Dataset, ax: Axis, title: str = "DAS", cycler: Cycler | None = PlotStyle().cycler
+    res: xr.Dataset,
+    ax: Axis,
+    title: str = "DAS",
+    cycler: Cycler | None = PlotStyle().cycler,
+    show_zero_line: bool = True,
 ) -> None:
     """Plot DAS (Decay Associated Spectra) on ``ax``.
 
@@ -103,6 +130,8 @@ def plot_das(
         Title of the plot. Defaults to "DAS".
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
+    show_zero_line: bool
+        Whether or not to add a horizontal line at zero. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
     keys = [
@@ -113,10 +142,16 @@ def plot_das(
         das.plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()
+    if show_zero_line is True:
+        ax.axhline(0, color="k", linewidth=1)
 
 
 def plot_norm_das(
-    res: xr.Dataset, ax: Axis, title: str = "norm DAS", cycler: Cycler | None = PlotStyle().cycler
+    res: xr.Dataset,
+    ax: Axis,
+    title: str = "norm DAS",
+    cycler: Cycler | None = PlotStyle().cycler,
+    show_zero_line: bool = True,
 ) -> None:
     """Plot normalized DAS (Decay Associated Spectra) on ``ax``.
 
@@ -130,6 +165,8 @@ def plot_norm_das(
         Title of the plot. Defaults to "norm DAS".
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
+    show_zero_line: bool
+        Whether or not to add a horizontal line at zero. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
     keys = [
@@ -140,3 +177,5 @@ def plot_norm_das(
         (das / np.abs(das).max(dim="spectral")).plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()
+    if show_zero_line is True:
+        ax.axhline(0, color="k", linewidth=1)

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -40,6 +40,7 @@ def plot_data_and_fits(
     per_axis_legend: bool = False,
     y_label: str = "a.u.",
     cycler: Cycler | None = PlotStyle().data_cycler_solid,
+    show_zero_line: bool = True,
 ) -> None:
     """Plot data and fits for a given ``wavelength`` on a given ``axis``.
 
@@ -72,6 +73,8 @@ def plot_data_and_fits(
         Label used for the y-axis of each subplot.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
+    show_zero_line: bool
+        Whether or not to add a horizontal line at zero. Defaults to True.
 
     See Also
     --------
@@ -94,6 +97,8 @@ def plot_data_and_fits(
             [next(axis._get_lines.prop_cycler) for _ in range(2)]
     if linlog:
         axis.set_xscale("symlog", linthresh=linthresh)
+    if show_zero_line is True:
+        axis.axhline(0, color="k", linewidth=1)
     axis.set_ylabel(y_label)
     if per_axis_legend is True:
         axis.legend()
@@ -113,6 +118,7 @@ def plot_fitted_traces(
     title: str = "Fit overview",
     y_label: str = "a.u.",
     cycler: Cycler | None = PlotStyle().data_cycler_solid,
+    show_zero_line: bool = True,
 ) -> tuple[Figure, Axes]:
     """Plot data and their fit in per wavelength plot grid.
 
@@ -148,6 +154,9 @@ def plot_fitted_traces(
         Label used for the y-axis of each subplot.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
+    show_zero_line: bool
+        Whether or not to add a horizontal line at zero. Defaults to True.
+
 
     Returns
     -------
@@ -189,6 +198,7 @@ def plot_fitted_traces(
             per_axis_legend=per_axis_legend,
             y_label=y_label,
             cycler=cycler,
+            show_zero_line=show_zero_line,
         )
     if per_axis_legend is False:
         add_unique_figure_legend(fig, axes)


### PR DESCRIPTION
This change adds the option `show_zero_line` to `plot_fitted_traces` (applied to all axes) and `plot_overview` (only applied to spectra SAS/DAS). The zero lines are added by default since it falls more in line with plots by @ism200 which makes comparing plots to former publications easier. 

### Change summary

- [:sparkles: Added show_zero_line arg to plot_overview and plot_fitted_traces](https://github.com/glotaran/pyglotaran-extras/commit/3f9c3a9971039b9a88cf29e614e3a51b66705f73)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)