### PR TITLE
🩹 Fix SVD vector labels always starting from zero

### DIFF
--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -338,7 +338,7 @@ def _plot_svd_vectors(
     if x_dim == sv_index_dim:
         values = values.T
         x_dim = vector_data.dims[0]
-    for index, (zorder, value) in enumerate(zip(range(100)[::-1], values)):
-        value.plot.line(x=x_dim, ax=ax, zorder=zorder, label=index)
+    for zorder, label, value in zip(range(100)[::-1], indices[:max_index], values):
+        value.plot.line(x=x_dim, ax=ax, zorder=zorder, label=label)
     if show_legend is True:
         ax.legend(title=sv_index_dim)


### PR DESCRIPTION
Since we mostly plot the first SVD vectors starting from zero we didn't see this bug yet.
But when you use different indices (e.g. to plot a specific vector) the legend still uses a range starting at zero.

```python
import matplotlib.pyplot as plt

from pyglotaran_extras.plotting.plot_svd import plot_lsv_residual

fig, axes = plt.subplots(1, 2, figsize=(20, 5))

plot_lsv_residual(result.data["dataset1"],axes[0], indices=[0])
plot_lsv_residual(result.data["dataset1"],axes[1], indices=[1])
```

## Before
![image](https://user-images.githubusercontent.com/9513634/215272337-5f3f6bb6-94d4-4c70-907f-2b6c590a27c8.png)

## After
![image](https://user-images.githubusercontent.com/9513634/215272324-900f9127-0469-4914-84c2-c597427300f1.png)


### Change summary

- [🩹 Fix SVD vector labels always starting from zero](https://github.com/glotaran/pyglotaran-extras/commit/2937cecbd15c66fdf2ccdbebb7d405646ea1fd84)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)