### PR TITLE
👌 Make result input for plot_coherent_artifact more generic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         minimum_pre_commit_version: 2.9.0

--- a/pyglotaran_extras/io/load_data.py
+++ b/pyglotaran_extras/io/load_data.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from warnings import warn
 
 import xarray as xr
 from glotaran.io import load_dataset
@@ -10,7 +11,9 @@ from glotaran.project.result import Result
 from pyglotaran_extras.types import DatasetConvertible
 
 
-def load_data(result: DatasetConvertible | Result, dataset_name: str | None = None) -> xr.Dataset:
+def load_data(
+    result: DatasetConvertible | Result, dataset_name: str | None = None, *, _stacklevel: int = 2
+) -> xr.Dataset:
     """Extract a single dataset from a :class:`DatasetConvertible` object.
 
     Parameters
@@ -20,6 +23,10 @@ def load_data(result: DatasetConvertible | Result, dataset_name: str | None = No
     dataset_name : str, optional
         Name of a specific dataset contained in ``result``, if not provided
         the first dataset will be extracted. Defaults to None.
+    _stacklevel: int
+        Stacklevel of the warning which is raised when ``result`` is of class ``Result``,
+        contains multiple datasets and no ``dataset_name`` is provided. Changing this value is
+        only required if you use this function inside of another function. Defaults to 2
 
     Returns
     -------
@@ -39,6 +46,15 @@ def load_data(result: DatasetConvertible | Result, dataset_name: str | None = No
         if dataset_name is not None:
             return result.data[dataset_name]
         keys = list(result.data)
+        if len(keys) > 1:
+            warn(
+                UserWarning(
+                    f"Result contains multiple datasets, auto selecting {keys[0]!r}.\n"
+                    f"Pass the dataset set you want to plot (e.g. result.data[{keys[0]!r}]) , "
+                    f"to deactivate this Warning.\nPossible dataset names are: {keys}"
+                ),
+                stacklevel=_stacklevel,
+            )
         return result.data[keys[0]]
     if isinstance(result, (str, Path)):
         return load_data(load_dataset(result))

--- a/pyglotaran_extras/plotting/plot_coherent_artifact.py
+++ b/pyglotaran_extras/plotting/plot_coherent_artifact.py
@@ -68,7 +68,7 @@ def plot_coherent_artifact(
     """
     fig, axes = plt.subplots(1, 2, figsize=figsize)
     add_cycler_if_not_none(axes, cycler)
-    dataset = load_data(dataset)
+    dataset = load_data(dataset, _stacklevel=3)
 
     if (
         "coherent_artifact_response" not in dataset

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -62,7 +62,7 @@ def plot_data_overview(
     tuple[Figure, Axes]
         Figure and axes which can then be refined by the user.
     """
-    dataset = load_data(dataset)
+    dataset = load_data(dataset, _stacklevel=3)
 
     fig = plt.figure(figsize=figsize)
     data_ax = cast(Axis, plt.subplot2grid((4, 3), (0, 0), colspan=3, rowspan=3, fig=fig))

--- a/pyglotaran_extras/plotting/plot_guidance.py
+++ b/pyglotaran_extras/plotting/plot_guidance.py
@@ -45,7 +45,7 @@ def plot_guidance(
     tuple[Figure, Axes]
         Figure and axes which can then be refined by the user.
     """
-    res = load_data(result)
+    res = load_data(result, _stacklevel=3)
     fig, axes = plt.subplots(1, 2, figsize=figsize)
 
     for axis in axes:

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -104,7 +104,7 @@ def plot_overview(
         If ``figure_only`` is True, Figure object which contains the plots (deprecated).
         If ``figure_only`` is False, Figure object which contains the plots and the Axes.
     """
-    res = load_data(result)
+    res = load_data(result, _stacklevel=3)
 
     if res.coords["time"].values.size == 1:
         fig, axes = plot_guidance(res)
@@ -197,7 +197,7 @@ def plot_simple_overview(
         If ``figure_only`` is True, Figure object which contains the plots (deprecated).
         If ``figure_only`` is False, Figure object which contains the plots and the Axes.
     """
-    res = load_data(result)
+    res = load_data(result, _stacklevel=3)
 
     fig, axes = plt.subplots(2, 3, figsize=figsize, constrained_layout=True)
     for ax in axes.flatten():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,10 @@
+# isort: off
+# Hack around https://github.com/pydata/xarray/issues/7259 which also affects pyglotaran <= 0.7.0
+import numpy  # noqa
+import netCDF4  # noqa
+
+# isort: on
+
 from dataclasses import replace
 
 import pytest

--- a/tests/io/test_load_data.py
+++ b/tests/io/test_load_data.py
@@ -1,0 +1,95 @@
+"""Tests for ``pyglotaran_extras.io.load_data``."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import xarray as xr
+from glotaran.io import load_result
+
+from pyglotaran_extras.io.load_data import load_data
+
+if TYPE_CHECKING:
+
+    from _pytest.recwarn import WarningsRecorder
+    from glotaran.project.result import Result
+
+MULTI_DATASET_WARING = (
+    "Result contains multiple datasets, auto selecting 'dataset_1'.\n"
+    "Pass the dataset set you want to plot (e.g. result.data['dataset_1']) , "
+    "to deactivate this Warning.\nPossible dataset names are: ['dataset_1', 'dataset_2']"
+)
+
+
+def run_load_data_test(result: xr.Dataset, compare: xr.Dataset | None = None):
+    """Factored out test runner function for ``test_load_data``."""
+    assert isinstance(result, xr.Dataset)
+    assert hasattr(result, "data")
+    if compare is not None:
+        assert result.equals(compare)
+
+
+def test_load_data(
+    result_sequential_spectral_decay: Result, tmp_path: Path, recwarn: WarningsRecorder
+):
+    """All input_type permutations result in a ``xr.Dataset``."""
+    compare_dataset = result_sequential_spectral_decay.data["dataset_1"]
+
+    from_result = load_data(result_sequential_spectral_decay)
+
+    run_load_data_test(from_result, compare_dataset)
+
+    from_dataset = load_data(compare_dataset)
+
+    run_load_data_test(from_dataset, compare_dataset)
+
+    result_sequential_spectral_decay.save(tmp_path / "result.yml")
+
+    from_file = load_data(tmp_path / "dataset_1.nc")
+
+    run_load_data_test(from_file, compare_dataset)
+
+    data_array = xr.DataArray([[1, 2], [3, 4]])
+    from_data_array = load_data(data_array)
+
+    run_load_data_test(from_data_array)
+    assert data_array.equals(from_data_array.data)
+
+    # No warning til now
+    assert len(recwarn) == 0
+
+    # Ensure not to mutate original fixture
+    result_multi_dataset = load_result(tmp_path / "result.yml")
+    result_multi_dataset.data["dataset_2"] = xr.Dataset({"foo": [1]})
+
+    from_result_multi_dataset = load_data(result_multi_dataset)
+
+    run_load_data_test(from_result_multi_dataset, compare_dataset)
+
+    assert len(recwarn) == 1
+
+    assert recwarn[0].category == UserWarning
+    assert recwarn[0].message.args[0] == MULTI_DATASET_WARING
+    assert Path(recwarn[0].filename) == Path(__file__)
+
+    def wrapped_call(result: Result):
+        return load_data(result, _stacklevel=3)
+
+    result_wrapped_call = wrapped_call(result_multi_dataset)
+
+    run_load_data_test(result_wrapped_call, compare_dataset)
+
+    assert len(recwarn) == 2
+
+    assert recwarn[1].category == UserWarning
+    assert recwarn[1].message.args[0] == MULTI_DATASET_WARING
+    assert Path(recwarn[1].filename) == Path(__file__)
+
+    with pytest.raises(TypeError) as excinfo:
+        load_data([1, 2])
+
+    assert str(excinfo.value) == (
+        "Result needs to be of type typing.Union[xarray.core.dataset.Dataset, "
+        "xarray.core.dataarray.DataArray, str, pathlib.Path], but was [1, 2]."
+    )


### PR DESCRIPTION
This PR allows the passing of `Result` and file paths as input to `plot_coherent_artifact` in addition users now get a warning when passing a `Result` with multiple datasets to the high level plot functions where `load_data` picks the first dataset for user convenience and to prevent crashes.

### Change summary

- [👌 Made result input for plot_coherent_artifact more generic](https://github.com/glotaran/pyglotaran-extras/commit/67b1d1df357b9b708ce3c42d60e0d73f76de71ba)
- [👌 Warn when picking a single dataset from a result with multiple datasets](https://github.com/glotaran/pyglotaran-extras/commit/d5f4ada001d5d396adeb1e804605460d754d9a04)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
