### PR TITLE
👌 Make plot_data_overview able to plot single trace data

### DIFF
--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -463,3 +463,22 @@ def calculate_ticks_in_units_of_pi(
     return tick_labels * np.pi, (
         str(val) for val in pretty_format_numerical_iterable(tick_labels, decimal_places=1)
     )
+
+
+def not_single_element_dims(data_array: xr.DataArray) -> list[Hashable]:
+    """Names of dimensions in ``data`` which don't have a size equal to one.
+
+    This helper function is for example used to determine if a data only have a single trace,
+    since this requires different plotting code (e.g. ``data_array.plot.line(x="time")``).
+
+    Parameters
+    ----------
+    data_array: xr.DataArray
+        _description_
+
+    Returns
+    -------
+    list[Hashable]
+        Names of dimensions in ``data`` which don't have a size equal to one.
+    """
+    return [dim for dim, values in data_array.coords.items() if values.size != 1]

--- a/tests/plotting/test_utils.py
+++ b/tests/plotting/test_utils.py
@@ -16,6 +16,7 @@ from pyglotaran_extras.plotting.style import PlotStyle
 from pyglotaran_extras.plotting.utils import abs_max
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
 from pyglotaran_extras.plotting.utils import calculate_ticks_in_units_of_pi
+from pyglotaran_extras.plotting.utils import not_single_element_dims
 
 matplotlib.use("Agg")
 DEFAULT_CYCLER = plt.rcParams["axes.prop_cycle"]
@@ -85,3 +86,22 @@ def test_calculate_ticks_in_units_of_pi(
 
     assert np.allclose(list(tick_values), expected_tick_values)
     assert list(tick_labels) == expected_tick_labels
+
+
+@pytest.mark.parametrize(
+    "data_array, expected",
+    (
+        (xr.DataArray([1]), []),
+        (xr.DataArray([1], coords={"dim1": [1]}), []),
+        (xr.DataArray([[1], [1]], coords={"dim1": [1, 2], "dim2": [1]}), ["dim1"]),
+        (
+            xr.DataArray(
+                [[[1, 1]], [[1, 1]]], coords={"dim1": [1, 2], "dim2": [1], "dim3": [1, 2]}
+            ),
+            ["dim1", "dim3"],
+        ),
+    ),
+)
+def test_not_single_element_dims(data_array: xr.DataArray, expected: list[Hashable]):
+    """Only get dim with more than one element."""
+    assert not_single_element_dims(data_array) == expected


### PR DESCRIPTION
This change allows `plot_data_overview` to be able to plot single trace data without crashing on a single axis dataset.
The SVD part of the plot will be skipped since it does not make sense.

Pseudo code to try it our:
```python
from glotaran.io import load_result
from pyglotaran_extras import plot_data_overview

result = load_result("my_result/result.yaml")
plot_data_overview(result.data['dataset1'].sel(spectral=0,method="nearest"))
```

### Change summary

- [✨ Implemented not_single_element_dims util function](https://github.com/glotaran/pyglotaran-extras/commit/32ce905ce4e0bca4c53c25ae2223ceac3a002485)
- [👌 Made plot_data_overview able to plot single trace data](https://github.com/glotaran/pyglotaran-extras/commit/17248849993759a3e11bb48a4eaf2b1dd5409957)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)