### PR TITLE
🩹 Fix heading in show_a_matrixes for multiple a-matrixes per dataset

### DIFF
--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -133,6 +133,7 @@ def show_a_matrixes(
             continue
 
         details_content = ""
+        header_newline_prefix = ""
 
         for a_matrix_name in a_matrix_names:
             mc_suffix = a_matrix_name.replace("a_matrix_", "")
@@ -142,7 +143,7 @@ def show_a_matrixes(
             if a_matrix_min_size is not None and max(a_matrix.shape) < a_matrix_min_size:
                 continue
 
-            details_content += f"###{heading_prefix} {mc_suffix}:\n\n"
+            details_content += f"{header_newline_prefix}###{heading_prefix} {mc_suffix}:\n\n"
 
             details_content += a_matrix_to_html_table(
                 a_matrix,
@@ -150,6 +151,7 @@ def show_a_matrixes(
                 normalize_initial_concentration=normalize_initial_concentration,
                 decimal_places=decimal_places,
             )
+            header_newline_prefix = "\n\n"
 
         if details_content != "":
             output_str += wrap_in_details_tag(

--- a/tests/data/a_matrix/show_a_matrixes_multiple_a_matrixes_in_dataset.md
+++ b/tests/data/a_matrix/show_a_matrixes_multiple_a_matrixes_in_dataset.md
@@ -1,0 +1,34 @@
+### A-Matrixes
+
+<details >
+<summary>
+<h4 style="display:inline;">
+dataset
+</h4>
+</summary>
+
+##### megacomplex_one:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>1    </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
+</tbody>
+</table>
+
+##### megacomplex_two:
+
+<table>
+<thead>
+<tr><th>species<br>initial concentration<br>lifetime↓  </th><th>species_1<br>1<br>&nbsp;  </th><th>Sum  </th></tr>
+</thead>
+<tbody>
+<tr><td>2                                              </td><td>1                         </td><td>1    </td></tr>
+<tr><td>Sum                                            </td><td>1                         </td><td>1    </td></tr>
+</tbody>
+</table>
+<br>
+</details>

--- a/tests/inspect/test_a_matrix.py
+++ b/tests/inspect/test_a_matrix.py
@@ -70,3 +70,33 @@ def test_show_a_matrixes(
     result.data["single_entry_a_matrix"] = xr.Dataset({"a_matrix_single_entry": single_entry_data})
 
     assert str(show_a_matrixes(result, **kwargs)) == expected.rstrip("\n")
+
+
+def test_show_a_matrixes_multiple_a_matrixes_in_dataset(
+    result_sequential_spectral_decay: Result,
+):
+    """Add two new lines in front of headings except for the first in a dataset."""
+    expected = (
+        TEST_DATA / "a_matrix/show_a_matrixes_multiple_a_matrixes_in_dataset.md"
+    ).read_text(encoding="utf8")
+
+    single_entry_data = result_sequential_spectral_decay.data[
+        "dataset_1"
+    ].a_matrix_megacomplex_sequential_decay[:1, :1]
+
+    a_matrix_one = single_entry_data.rename(
+        {
+            name: name.replace("megacomplex_sequential_decay", "megacomplex_one")
+            for name in single_entry_data.coords
+        }
+    )
+    a_matrix_two = single_entry_data.rename(
+        {
+            name: name.replace("megacomplex_sequential_decay", "megacomplex_two")
+            for name in single_entry_data.coords
+        }
+    )
+    dummy_dataset = xr.Dataset(
+        {"a_matrix_megacomplex_one": a_matrix_one, "a_matrix_megacomplex_two": a_matrix_two}
+    )
+    assert str(show_a_matrixes(dummy_dataset)) == expected.rstrip("\n")


### PR DESCRIPTION
Just 2 additional new lines in front of the heading above the table (megacomplex name), so it renders as heading.

### Change summary

- [🩹 Fixed missing new lines in front of megacomplex heading](https://github.com/glotaran/pyglotaran-extras/commit/18dd39426139892e468f1ae8961daccd8f84818f)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
