### PR TITLE
👌 Improve plot_doas default legend_format_string

### DIFF
--- a/pyglotaran_extras/plotting/plot_doas.py
+++ b/pyglotaran_extras/plotting/plot_doas.py
@@ -37,9 +37,9 @@ def plot_doas(
     cycler: Cycler | None = PlotStyle().cycler,
     oscillation_type: Literal["cos", "sin"] = "cos",
     title: str | None = "Damped oscillations",
-    legend_format_string: str = "{label}: v={frequency:.0f}, Γ={rate:.1f}",
+    legend_format_string: str = r"{label}: $\nu$={frequency:.0f}, $\gamma$={rate:.1f}",
 ) -> tuple[Figure, Axes]:
-    """Plot DOAS (Damped Oscillation) related data of the optimization result.
+    r"""Plot DOAS (Damped Oscillation) related data of the optimization result.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def plot_doas(
         Format string for each entry in the legend of the oscillation plot. Possible values which
         can be replaced are ``label`` (label of the oscillation in the model definition),
         ``frequency`` and ``rate``. Use ``""`` to remove the legend. Defaults to
-        ``"{label}: v={frequency:.0f}, Γ={rate:.1f}"``
+        ``r"{label}: $\nu$={frequency:.0f}, $\gamma$={rate:.1f}"``
 
     Returns
     -------


### PR DESCRIPTION
Looks like matplotlib can render tex math style with activating latex nowadays so we can replace `"{label}: v={frequency:.0f}, Γ={rate:.1f}"` with `r"{label}: $\nu$={frequency:.0f}, $\gamma$={rate:.1f}"` (changing the gamma to the lower case version was on request of @ism200 ).

### Change summary

- [👌 Improve plot_doas default legend_format_string](https://github.com/glotaran/pyglotaran-extras/commit/5b39dd8f2e59a9da4c13b29c7ceb3d4e4edd6786)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)