### PR TITLE
🩹⌨️ Fix figsize typing

### DIFF
--- a/pyglotaran_extras/plotting/plot_coherent_artifact.py
+++ b/pyglotaran_extras/plotting/plot_coherent_artifact.py
@@ -29,7 +29,7 @@ def plot_coherent_artifact(
     spectral: float = 0,
     main_irf_nr: int | None = 0,
     normalize: bool = True,
-    figsize: tuple[int, int] = (18, 7),
+    figsize: tuple[float, float] = (18, 7),
     show_zero_line: bool = True,
     cycler: Cycler | None = None,
     title: str | None = "Coherent Artifact",
@@ -58,7 +58,7 @@ def plot_coherent_artifact(
         Whether or not to normalize the IRF derivative plot. If the IRF derivative is normalized,
         the IRFAS is scaled with the reciprocal of the normalization to compensate for this.
         Defaults to True.
-    figsize: tuple[int, int]
+    figsize: tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (18, 7).
     show_zero_line: bool
         Whether or not to add a horizontal line at zero. Defaults to True.

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -33,7 +33,7 @@ def plot_data_overview(
     title: str = "Data overview",
     linlog: bool = False,
     linthresh: float = 1,
-    figsize: tuple[int, int] = (15, 10),
+    figsize: tuple[float, float] = (15, 10),
     nr_of_data_svd_vectors: int = 4,
     show_data_svd_legend: bool = True,
     irf_location: float | None = None,
@@ -119,7 +119,7 @@ def _plot_single_trace(
     title: str = "Single trace data",
     linlog: bool = False,
     linthresh: float = 1,
-    figsize: tuple[int, int] = (15, 10),
+    figsize: tuple[float, float] = (15, 10),
 ) -> tuple[Figure, Axis]:
     """Plot single trace data in case ``plot_data_overview`` gets passed ingle trace data.
 
@@ -136,7 +136,7 @@ def _plot_single_trace(
     linthresh: float
         A single float which defines the range (-x, x), within which the plot is linear.
         This avoids having the plot go to infinity around zero. Defaults to 1.
-    figsize: tuple[int, int]
+    figsize: tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (15, 10).
 
     Returns

--- a/pyglotaran_extras/plotting/plot_doas.py
+++ b/pyglotaran_extras/plotting/plot_doas.py
@@ -32,7 +32,7 @@ def plot_doas(
     spectral: float = 0,
     main_irf_nr: int | None = 0,
     normalize: bool = False,
-    figsize: tuple[int, int] = (20, 5),
+    figsize: tuple[float, float] = (20, 5),
     show_zero_line: bool = True,
     cycler: Cycler | None = PlotStyle().cycler,
     oscillation_type: Literal["cos", "sin"] = "cos",
@@ -65,7 +65,7 @@ def plot_doas(
         Whether or not to normalize the DOAS spectra plot. If the DOAS spectra is normalized,
         the Oscillation is scaled with the reciprocal of the normalization to compensate for this.
         Defaults to False.
-    figsize: tuple[int, int]
+    figsize: tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (20, 5)
     show_zero_line: bool
         Whether or not to add a horizontal line at zero. Defaults to True

--- a/pyglotaran_extras/plotting/plot_guidance.py
+++ b/pyglotaran_extras/plotting/plot_guidance.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 def plot_guidance(
     result: DatasetConvertible | Result,
-    figsize: tuple[int, int] = (15, 5),
+    figsize: tuple[float, float] = (15, 5),
     title: str = "Guidance Overview",
     y_label: str = "a.u.",
     cycler: Cycler | None = PlotStyle().cycler,
@@ -31,7 +31,7 @@ def plot_guidance(
     ----------
     result: DatasetConvertible | Result
         Result from a pyglotaran optimization as dataset, Path or Result object.
-    figsize: tuple[int, int]
+    figsize: tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (15, 5)
     title: str
         Title to add to the figure. Defaults to "Guidance Overview"

--- a/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
+++ b/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 def plot_irf_dispersion_center(
     result: ResultLike,
     ax: Axis | None = None,
-    figsize: tuple[int, int] = (12, 8),
+    figsize: tuple[float, float] = (12, 8),
     cycler: Cycler | None = PlotStyle().cycler,
     irf_location: float | None = None,
 ) -> tuple[Figure, Axis] | None:
@@ -38,7 +38,7 @@ def plot_irf_dispersion_center(
         Data structure which can be converted to a mapping.
     ax : Axis | None
         Axis to plot on. Defaults to None which means that a new figure and axis will be created.
-    figsize: tuple[int, int]
+    figsize: tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (12, 8).
     cycler: Cycler
         Plot style cycler to use. Defaults to PlotStyle().cycler

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -39,7 +39,7 @@ def plot_overview(
     linscale: float = 1,
     show_data: bool | None = False,
     main_irf_nr: int = 0,
-    figsize: tuple[int, int] = (18, 16),
+    figsize: tuple[float, float] = (18, 16),
     cycler: Cycler | None = PlotStyle().cycler,
     figure_only: bool = True,
     nr_of_data_svd_vectors: int = 4,
@@ -162,7 +162,7 @@ def plot_overview(
 def plot_simple_overview(
     result: DatasetConvertible | Result,
     title: str | None = None,
-    figsize: tuple[int, int] = (12, 6),
+    figsize: tuple[float, float] = (12, 6),
     cycler: Cycler | None = PlotStyle().cycler,
     figure_only: bool = True,
     show_irf_dispersion_center: bool = True,

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -114,7 +114,7 @@ def plot_fitted_traces(
     linthresh: float = 1,
     divide_by_scale: bool = True,
     per_axis_legend: bool = False,
-    figsize: tuple[int, int] = (30, 15),
+    figsize: tuple[float, float] = (30, 15),
     title: str = "Fit overview",
     y_label: str = "a.u.",
     cycler: Cycler | None = PlotStyle().data_cycler_solid,


### PR DESCRIPTION
Just a minor fix for the typing of the `figsize` argument which currently is `tuple[int, int]` but should be `tuple[float, float]`.
See [matplotlib docs](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.figure.html)

### Change summary

- [🩹⌨️ Fix figsize typing](https://github.com/glotaran/pyglotaran-extras/commit/3d2eb2b1a319dba6d038082ec1462a5333a154e3)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)