### PR TITLE
🩹📚 Fix search in docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - 🩹🚇 Fix 'Test pyglotaran dev' CI step (#117)
 - 👌 Add option to deactivate data/residual plotting in overview plots (#118)
+- 🩹📚 Fix search in docs (#157)
 
 (changes-0_6_0)=
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "myst_parser",
+    "sphinx_rtd_theme",
 ]
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,10 @@
 # documentation dependencies
 Sphinx>=3.2.0
 myst-parser>=0.12.0
-sphinx-rtd-theme>=0.5.1
+sphinx-rtd-theme>=1.2.0
+# Needed for the search to work
+# Ref.: https://github.com/readthedocs/sphinx_rtd_theme/issues/1434
+sphinxcontrib-jquery>=4.1
 sphinx-copybutton>=0.3.0
 numpydoc>=0.8.0
 # notebook docs


### PR DESCRIPTION
Currently, the search functionality in our docs hangs indefinitely.
The error you get in the dev tools console is 
```js
Uncaught ReferenceError: jQuery is not defined
```
This relates to a change in the rtd theme and how to use it (old config).

### Change summary

- [🩹📚 Fix search in docs](https://github.com/glotaran/pyglotaran-extras/commit/0b991d721c114af42fd98ca6b6feb054682186dc)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)