### PR TITLE
🩹 Fix crashes of plot_doas and plot_coherent_artifact for non dispersive IRF

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ## 0.8.0 (Unreleased)
 
+- 🩹 Fix crashes of plot_doas and plot_coherent_artifact for non dispersive IRF (#173)
+
 (changes-0_7_0)=
 
 ## 0.7.0 (2023-04-15)

--- a/pyglotaran_extras/plotting/plot_coherent_artifact.py
+++ b/pyglotaran_extras/plotting/plot_coherent_artifact.py
@@ -103,9 +103,10 @@ def plot_coherent_artifact(
         norm_factor = scales.max()
         irf_y_label = f"normalized {irf_y_label}"
 
-    plot_slice_irf = (
-        irf_data.sel(spectral=spectral, method="nearest") / irf_max * scales / norm_factor
-    )
+    if "spectral" in irf_data:
+        irf_data = irf_data.sel(spectral=spectral, method="nearest")
+
+    plot_slice_irf = irf_data / irf_max * scales / norm_factor
     irf_sel_kwargs = (
         {"time": slice(time_range[0], time_range[1])} if time_range is not None else {}
     )

--- a/pyglotaran_extras/plotting/plot_doas.py
+++ b/pyglotaran_extras/plotting/plot_doas.py
@@ -105,11 +105,13 @@ def plot_doas(
 
     irf_location = extract_irf_location(dataset, spectral, main_irf_nr)
 
+    oscillations = dataset[f"damped_oscillation_{oscillation_type}"]
+
+    if "spectral" in oscillations.coords:
+        oscillations = oscillations.sel(spectral=spectral, method="nearest")
+
     oscillations = shift_time_axis_by_irf_location(
-        dataset[f"damped_oscillation_{oscillation_type}"]
-        .sel(spectral=spectral, method="nearest")
-        .sel(**osc_sel_kwargs),
-        irf_location,
+        oscillations.sel(**osc_sel_kwargs), irf_location
     )
     oscillations_spectra = dataset["damped_oscillation_associated_spectra"].sel(**osc_sel_kwargs)
 


### PR DESCRIPTION
This fixes crashes of `plot_doas` and `plot_coherent_artifact` where an IRF without dispersion is used which omits the spectral dimension in the result data.

### Change summary

- [🩹 Added check that spectral coord exists on data before selecting](https://github.com/glotaran/pyglotaran-extras/commit/8c6d7c6fd76c4f882fbfa0e1b9c49c70a8b600c8)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)

