### PR TITLE
🚧📦 Remove upper python version limit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ## 0.8.0 (Unreleased)
 
 - 🩹 Fix crashes of plot_doas and plot_coherent_artifact for non dispersive IRF (#173)
+- 🚧📦 Remove upper python version limit (#174)
 
 (changes-0_7_0)=
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
@@ -36,7 +36,7 @@ install_requires =
     pyglotaran>=0.7
     tabulate>=0.8.9
     xarray>=2022.3.0
-python_requires = >=3.10,<3.11
+python_requires = >=3.10
 zip_safe = True
 
 [options.packages.find]


### PR DESCRIPTION
The upper python version limit will be determined by our dependencies (i.e. `pyglotaran`) so there is no need for us to set it.
This will allow us to raise the upper python version limit of `pyglotaran` without a new release of the extras and removes a kind of racing condition with the upper bounds.

### Change summary

- [🚧📦 Remove upper python version limit](https://github.com/glotaran/pyglotaran-extras/commit/9fb15ebaa2a9ef367c679fb19d459874ddcb5d7a)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)