### PR TITLE
🩹 Fix crashes `plot_coherent_artifact` with none dispersive IRF

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ## 0.8.0 (Unreleased)
 
-- 🩹 Fix crashes of plot_doas and plot_coherent_artifact for non dispersive IRF (#173)
+- 🩹 Fix crashes of plot_doas and plot_coherent_artifact for non dispersive IRF (#173, #182)
 - 👌 Add minor ticks to linlog plots (#183)
 - 🚧📦 Remove upper python version limit (#174)
 

--- a/pyglotaran_extras/plotting/plot_coherent_artifact.py
+++ b/pyglotaran_extras/plotting/plot_coherent_artifact.py
@@ -103,7 +103,7 @@ def plot_coherent_artifact(
         norm_factor = scales.max()
         irf_y_label = f"normalized {irf_y_label}"
 
-    if "spectral" in irf_data:
+    if "spectral" in irf_data.coords:
         irf_data = irf_data.sel(spectral=spectral, method="nearest")
 
     plot_slice_irf = irf_data / irf_max * scales / norm_factor


### PR DESCRIPTION
This fixes crashes `plot_coherent_artifact` where an IRF without dispersion is used which omits the spectral dimension in the result data.

### Change summary

- [🩹](https://github.com/glotaran/pyglotaran-extras/commit/53bbfb282fb175a038cd973ac80be686a2b22a6a) [Follow up fix for](https://github.com/glotaran/pyglotaran-extras/commit/53bbfb282fb175a038cd973ac80be686a2b22a6a) https://github.com/glotaran/pyglotaran-extras/pull/173

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
