### PR TITLE
👌 Add minor ticks to linlog plots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ## 0.8.0 (Unreleased)
 
 - 🩹 Fix crashes of plot_doas and plot_coherent_artifact for non dispersive IRF (#173)
+- 👌 Add minor ticks to linlog plots (#183)
 - 🚧📦 Remove upper python version limit (#174)
 
 (changes-0_7_0)=

--- a/pyglotaran_extras/plotting/plot_concentrations.py
+++ b/pyglotaran_extras/plotting/plot_concentrations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from pyglotaran_extras.plotting.style import PlotStyle
+from pyglotaran_extras.plotting.utils import MinorSymLogLocator
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
 from pyglotaran_extras.plotting.utils import get_shifted_traces
 
@@ -69,3 +70,4 @@ def plot_concentrations(
 
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh, linscale=linscale)
+        ax.xaxis.set_minor_locator(MinorSymLogLocator(linthresh))

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -12,6 +12,7 @@ from pyglotaran_extras.io.load_data import load_data
 from pyglotaran_extras.plotting.plot_svd import plot_lsv_data
 from pyglotaran_extras.plotting.plot_svd import plot_rsv_data
 from pyglotaran_extras.plotting.plot_svd import plot_sv_data
+from pyglotaran_extras.plotting.utils import MinorSymLogLocator
 from pyglotaran_extras.plotting.utils import not_single_element_dims
 from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 
@@ -109,6 +110,7 @@ def plot_data_overview(
 
     if linlog:
         data_ax.set_xscale("symlog", linthresh=linthresh)
+        data_ax.xaxis.set_minor_locator(MinorSymLogLocator(linthresh))
     return fig, (data_ax, lsv_ax, sv_ax, rsv_ax)
 
 
@@ -150,4 +152,5 @@ def _plot_single_trace(
 
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
+        ax.xaxis.set_minor_locator(MinorSymLogLocator(linthresh))
     return fig, ax

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from pyglotaran_extras.plotting.plot_irf_dispersion_center import _plot_irf_dispersion_center
 from pyglotaran_extras.plotting.style import PlotStyle
+from pyglotaran_extras.plotting.utils import MinorSymLogLocator
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
 from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 
@@ -83,4 +84,5 @@ def plot_residual(
         ax.legend()
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
+        ax.xaxis.set_minor_locator(MinorSymLogLocator(linthresh))
     ax.set_title(title)

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from glotaran.io.prepare_dataset import add_svd_to_dataset
 
 from pyglotaran_extras.plotting.style import PlotStyle
+from pyglotaran_extras.plotting.utils import MinorSymLogLocator
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
 from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 
@@ -140,6 +141,7 @@ def plot_lsv_data(
     ax.set_title("data. LSV")
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
+        ax.xaxis.set_minor_locator(MinorSymLogLocator(linthresh))
 
 
 def plot_rsv_data(
@@ -240,6 +242,7 @@ def plot_lsv_residual(
     ax.set_title("res. LSV")
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
+        ax.xaxis.set_minor_locator(MinorSymLogLocator(linthresh))
 
 
 def plot_rsv_residual(

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 
 from pyglotaran_extras.io.utils import result_dataset_mapping
 from pyglotaran_extras.plotting.style import PlotStyle
+from pyglotaran_extras.plotting.utils import MinorSymLogLocator
 from pyglotaran_extras.plotting.utils import PlotDuplicationWarning
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
 from pyglotaran_extras.plotting.utils import add_unique_figure_legend
@@ -97,6 +98,7 @@ def plot_data_and_fits(
             [next(axis._get_lines.prop_cycler) for _ in range(2)]
     if linlog:
         axis.set_xscale("symlog", linthresh=linthresh)
+        axis.xaxis.set_minor_locator(MinorSymLogLocator(linthresh))
     if show_zero_line is True:
         axis.axhline(0, color="k", linewidth=1)
     axis.set_ylabel(y_label)


### PR DESCRIPTION
This change adds minor ticks to linlog plots which makes it easier to differentiate between the linear and logarithmic parts.

### Before
![image](https://github.com/glotaran/pyglotaran-extras/assets/9513634/efa1cc12-4023-4894-a20b-ea7859359fe5)
### After
![image](https://github.com/glotaran/pyglotaran-extras/assets/9513634/8edb2d6f-03ca-4ea9-8587-e42e9f3402a6)


### Change summary

- [👌 Add minor ticks to linlog plots](https://github.com/glotaran/pyglotaran-extras/commit/686a9555703aabb7a1bc04e8667be173128359a6)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)