### PR TITLE
🚧 Back to 0.8.0 development

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,10 +32,10 @@ jobs:
         example_name: ${{fromJson(needs.create-example-list.outputs.example-list)}}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install pyglotaran-extras
         run: |
           pip install wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.10"]
 
     steps:
       - name: Check out repo

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Can be installed as a python package or from sources.
 
 Prerequisites:
 
-- Python 3.8, 3.9 or 3.10
-- Python package `pyglotaran` v0.6.0 (or later)
+- Python 3.10 or 3.11
+- Python package `pyglotaran` v0.7.0 (or later)
 
 ### Stable Release
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - jupyter-offlinenotebook=0.2
   # Python Kernel
   - ipykernel>5.1
-  - python=3.8
+  - python=3.10
   # update outdated repo2docker version
   - pip
   - pip:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+(changes-0_8_0)=
+
+## 0.8.0 (Unreleased)
+
 (changes-0_7_1)=
 
 ## 0.7.1 (2023-07-27)

--- a/pyglotaran_extras/__init__.py
+++ b/pyglotaran_extras/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "add_subplot_labels",
 ]
 
-__version__ = "0.7.1"
+__version__ = "0.8.0.dev0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,10 +33,10 @@ install_requires =
     cycler>=0.10
     matplotlib>=3.3.0
     numpy>=1.21.2,<1.24
-    pyglotaran>=0.6
+    pyglotaran>=0.7
     tabulate>=0.8.9
     xarray>=2022.3.0
-python_requires = >=3.8
+python_requires = >=3.10
 zip_safe = True
 
 [options.packages.find]


### PR DESCRIPTION
After the `0.7.1` release we can go back to the `0.8.0` development

### Change summary

- Update minimum Python version from 3.8 to 3.10
- [🚧 Back to 0.8.0 development](https://github.com/glotaran/pyglotaran-extras/commit/321250e40bd418320dd44584a0d53fd89a803998)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
