### PR TITLE
🧰👌 Switch tooling to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,3 +142,8 @@ repos:
         types: [file]
         types_or: [python, pyi, markdown, rst, jupyter]
         args: ["--ignore-words-list=doas"]
+
+  - repo: https://github.com/s-weigand/pre-commit_mirrors-actionlint
+    rev: "v1.6.24"
+    hooks:
+      - id: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0 # Use the sha or tag you want to point at
+    rev: v3.0.1 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
 
@@ -95,12 +95,12 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.278
+    rev: v0.0.282
     hooks:
       - id: ruff
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         alias: flake8-docs
@@ -113,7 +113,7 @@ repos:
           - "--skip-checking-short-docstrings=False"
         name: "flake8 lint docstrings"
         exclude: "^(docs/|setup.py$|tests?/)"
-        additional_dependencies: [pydoclint==0.0.16]
+        additional_dependencies: [pydoclint==0.1.4]
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: "v6.1.2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,7 @@ repos:
           - "--skip-checking-short-docstrings=False"
         name: "flake8 lint docstrings"
         exclude: "^(docs/|setup.py$|tests?/)"
-        additional_dependencies: [pydoclint]
+        additional_dependencies: [pydoclint==0.0.8]
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: "v6.1.2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,12 +100,11 @@ repos:
         pass_filenames: false
         additional_dependencies: [click<8]
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.270
     hooks:
-      - id: flake8
-        args:
-          - "--max-line-length=99"
+      - id: ruff
 
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
@@ -113,15 +112,15 @@ repos:
       - id: flake8
         alias: flake8-docs
         args:
-          - "--select=D,DOC"
-          - "--extend-ignore= DOC502"
+          - "--select=DOC"
+          - "--extend-ignore=DOC502"
           - "--color=always"
           - "--require-return-section-when-returning-none=False"
           - "--allow-init-docstring=True"
           - "--skip-checking-short-docstrings=False"
         name: "flake8 lint docstrings"
         exclude: "^(docs/|setup.py$|tests?/)"
-        additional_dependencies: [flake8-docstrings, pydoclint]
+        additional_dependencies: [pydoclint]
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: "v6.1.2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,16 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.1
+    rev: v1.7.5
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]
         args: [--in-place, --config, ./pyproject.toml]
+
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: "0.13.0"
+    hooks:
+      - id: pyproject-fmt
 
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
@@ -28,7 +33,7 @@ repos:
       - id: absolufy-imports
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3
@@ -45,7 +50,7 @@ repos:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode # Use the sha or tag you want to point at
+    rev: v3.0.0 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
 
@@ -60,7 +65,7 @@ repos:
     rev: 1.7.0
     hooks:
       - id: nbqa-black
-        additional_dependencies: [black==22.6.0]
+        additional_dependencies: [black==23.7.0]
         args: [--nbqa-mutate]
       - id: nbqa-pyupgrade
         additional_dependencies: [pyupgrade==2.37.2]
@@ -68,7 +73,7 @@ repos:
       - id: nbqa-flake8
       - id: nbqa-check-ast
       - id: nbqa-isort
-        additional_dependencies: [isort==5.10.1]
+        additional_dependencies: [isort==5.12.0]
         args: [--nbqa-mutate]
 
   # Linters
@@ -90,7 +95,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.270
+    rev: v0.0.278
     hooks:
       - id: ruff
 
@@ -108,7 +113,7 @@ repos:
           - "--skip-checking-short-docstrings=False"
         name: "flake8 lint docstrings"
         exclude: "^(docs/|setup.py$|tests?/)"
-        additional_dependencies: [pydoclint==0.0.8]
+        additional_dependencies: [pydoclint==0.0.10]
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: "v6.1.2"
@@ -130,7 +135,7 @@ repos:
         types_or: [python, pyi, markdown, rst, jupyter]
         args: ["--ignore-words-list=doas"]
 
-  - repo: https://github.com/s-weigand/pre-commit_mirrors-actionlint
-    rev: "v1.6.24"
+  - repo: https://github.com/rhysd/actionlint
+    rev: "v1.6.25"
     hooks:
       - id: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     rev: v1.5.0
     hooks:
       - id: yesqa
-        additional_dependencies: [flake8-docstrings]
+        additional_dependencies: [flake8-docstrings, flake8-print]
 
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,15 +39,6 @@ repos:
       - id: isort
         minimum_pre_commit_version: 2.9.0
 
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.5.0
-    hooks:
-      - id: yesqa
-        additional_dependencies:
-          - flake8-docstrings
-          - flake8-print
-          - pep8-naming
-
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     rev: v1.5.0
     hooks:
       - id: yesqa
-        additional_dependencies: [flake8-docstrings, darglint==1.8.0]
+        additional_dependencies: [flake8-docstrings]
 
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.4.0
@@ -113,10 +113,15 @@ repos:
       - id: flake8
         alias: flake8-docs
         args:
-          - "--select=D,DAR"
+          - "--select=D,DOC"
+          - "--extend-ignore= DOC502"
+          - "--color=always"
+          - "--require-return-section-when-returning-none=False"
+          - "--allow-init-docstring=True"
+          - "--skip-checking-short-docstrings=False"
         name: "flake8 lint docstrings"
         exclude: "^(docs/|setup.py$|tests?/)"
-        additional_dependencies: [flake8-docstrings, darglint==1.8.0]
+        additional_dependencies: [flake8-docstrings, pydoclint]
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: "v6.1.2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,10 @@ repos:
     rev: v1.5.0
     hooks:
       - id: yesqa
-        additional_dependencies: [flake8-docstrings, flake8-print]
+        additional_dependencies:
+          - flake8-docstrings
+          - flake8-print
+          - pep8-naming
 
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,13 @@ repos:
       - id: fix-encoding-pragma
         args: [--remove]
 
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.1
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: [--in-place, --config, ./pyproject.toml]
+
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
           - "--skip-checking-short-docstrings=False"
         name: "flake8 lint docstrings"
         exclude: "^(docs/|setup.py$|tests?/)"
-        additional_dependencies: [pydoclint==0.0.10]
+        additional_dependencies: [pydoclint==0.0.16]
 
   - repo: https://github.com/rstcheck/rstcheck
     rev: "v6.1.2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,6 @@ repos:
     hooks:
       - id: absolufy-imports
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 [![Documentation Status](https://readthedocs.org/projects/pyglotaran-extras/badge/?version=latest)](https://pyglotaran-extras.readthedocs.io/en/latest/?badge=latest)
 [![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/glotaran/pyglotaran-extras.git/main?urlpath=lab%2Ftree%2Fdocs%2Fsource%2Fnotebooks)
 
-[![codecov](https://codecov.io/gh/glotaran/pyglotaran-extras/branch/main/graph/badge.svg?token=I6F412Y390)](https://codecov.io/gh/glotaran/pyglotaran-extras)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Code style Python: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
+[![codecov](https://codecov.io/gh/glotaran/pyglotaran-extras/branch/main/graph/badge.svg?token=I6F412Y390)](https://codecov.io/gh/glotaran/pyglotaran-extras)
 [![Discord](https://img.shields.io/discord/883443835135475753.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/KfnEYRSTJx)
 
 Supplementary package for pyglotaran with (example) plotting code for use with the pyglotaran package.

--- a/pyglotaran_extras/deprecation/deprecation_utils.py
+++ b/pyglotaran_extras/deprecation/deprecation_utils.py
@@ -10,7 +10,7 @@ FIG_ONLY_WARNING = (
 )
 
 
-class OverDueDeprecation(Exception):
+class OverDueDeprecationError(Exception):
     """Error thrown when a deprecation should have been removed.
 
     See Also
@@ -109,7 +109,7 @@ def check_overdue(deprecated_qual_name_usage: str, to_be_removed_in_version: str
             f"was supposed to be dropped in version: {to_be_removed_in_version!r}.\n"
             f"Current version is: {pyglotaran_extras_version()!r}"
         )
-        raise OverDueDeprecation(msg)
+        raise OverDueDeprecationError(msg)
 
 
 def warn_deprecated(

--- a/pyglotaran_extras/deprecation/deprecation_utils.py
+++ b/pyglotaran_extras/deprecation/deprecation_utils.py
@@ -104,11 +104,12 @@ def check_overdue(deprecated_qual_name_usage: str, to_be_removed_in_version: str
         parse_version(pyglotaran_extras_version()) >= parse_version(to_be_removed_in_version)
         and "dev" not in pyglotaran_extras_version()
     ):
-        raise OverDueDeprecation(
-            f"Support for {deprecated_qual_name_usage.partition('(')[0]!r} was "
-            f"supposed to be dropped in version: {to_be_removed_in_version!r}.\n"
+        msg = (
+            f"Support for {deprecated_qual_name_usage.partition('(')[0]!r} "
+            f"was supposed to be dropped in version: {to_be_removed_in_version!r}.\n"
             f"Current version is: {pyglotaran_extras_version()!r}"
         )
+        raise OverDueDeprecation(msg)
 
 
 def warn_deprecated(

--- a/pyglotaran_extras/deprecation/deprecation_utils.py
+++ b/pyglotaran_extras/deprecation/deprecation_utils.py
@@ -133,16 +133,13 @@ def warn_deprecated(
     to_be_removed_in_version : str
         Version the support for this usage will be removed.
 
-    stacklevel: int
+    stacklevel : int
         Stack at which the warning should be shown as raise. Default: 2
 
     Raises
     ------
     OverDueDeprecation
         If the current version is greater or equal to ``to_be_removed_in_version``.
-
-
-    -- noqa: DAR402
     """
     check_overdue(deprecated_qual_name_usage, to_be_removed_in_version)
     warn(

--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -25,13 +25,13 @@ def a_matrix_to_html_table(
 
     Parameters
     ----------
-    a_matrix: xr.DataArray
+    a_matrix : xr.DataArray
         DataArray containing the a-matrix values and coordinates.
-    megacomplex_suffix: str
+    megacomplex_suffix : str
         Megacomplex suffix used for the a-matrix data variable and coordinate names.
-    normalize_initial_concentration: bool
+    normalize_initial_concentration : bool
         Whether or not to normalize the initial concentration. Defaults to False.
-    decimal_places: int
+    decimal_places : int
         Decimal places to display. Defaults to 3.
 
     Returns
@@ -96,18 +96,18 @@ def show_a_matrixes(
 
     Parameters
     ----------
-    result: ResultLike
+    result : ResultLike
         Result or result dataset.
-    normalize_initial_concentration: bool
+    normalize_initial_concentration : bool
         Whether or not to normalize the initial concentration. Defaults to False.
-    decimal_places: int
+    decimal_places : int
         Decimal places to display. Defaults to 3.
-    a_matrix_min_size: int
+    a_matrix_min_size : int | None
         Defaults to None.
-    expanded_datasets: tuple[str, ...]
+    expanded_datasets : tuple[str, ...]
         Names of dataset to expand the details view for. Defaults to empty tuple () which means no
         dataset is expanded.
-    heading_offset: int
+    heading_offset : int
         Number of heading level to offset the headings. Defaults to 2 which means that the
         first/top most heading is h3.
 

--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -39,12 +39,12 @@ def a_matrix_to_html_table(
     str
         Multi header HTML table representing the a-matrix.
     """
-    species = a_matrix.coords[f"species_{megacomplex_suffix}"].values
+    species = a_matrix.coords[f"species_{megacomplex_suffix}"].to_numpy()
     # Crete a copy so normalization does not mutate the original values
     initial_concentration = np.array(
-        a_matrix.coords[f"initial_concentration_{megacomplex_suffix}"].values
+        a_matrix.coords[f"initial_concentration_{megacomplex_suffix}"].to_numpy()
     )
-    lifetime = a_matrix.coords[f"lifetime_{megacomplex_suffix}"].values
+    lifetime = a_matrix.coords[f"lifetime_{megacomplex_suffix}"].to_numpy()
 
     if normalize_initial_concentration is True:
         initial_concentration /= initial_concentration.sum()
@@ -66,7 +66,7 @@ def a_matrix_to_html_table(
     ]
     data.append(
         pretty_format_numerical_iterable(
-            ("Sum", *a_matrix.values.sum(axis=0), a_matrix.values.sum()),
+            ("Sum", *a_matrix.to_numpy().sum(axis=0), a_matrix.to_numpy().sum()),
             decimal_places=decimal_places,
         )
     )

--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-import xarray as xr
 from glotaran.utils.ipython import MarkdownStr
 from tabulate import tabulate
 
@@ -11,7 +12,11 @@ from pyglotaran_extras.inspect.utils import pretty_format_numerical
 from pyglotaran_extras.inspect.utils import pretty_format_numerical_iterable
 from pyglotaran_extras.inspect.utils import wrap_in_details_tag
 from pyglotaran_extras.io.utils import result_dataset_mapping
-from pyglotaran_extras.types import ResultLike
+
+if TYPE_CHECKING:
+    import xarray as xr
+
+    from pyglotaran_extras.types import ResultLike
 
 
 def a_matrix_to_html_table(

--- a/pyglotaran_extras/inspect/a_matrix.py
+++ b/pyglotaran_extras/inspect/a_matrix.py
@@ -58,7 +58,7 @@ def a_matrix_to_html_table(
         ["species<br>initial concentration<br>lifetime↓"]
         + [
             f"{sp}<br>{pretty_format_numerical(ic,decimal_places)}<br>&nbsp;"
-            for sp, ic in zip(species, initial_concentration)
+            for sp, ic in zip(species, initial_concentration, strict=True)
         ]
         + ["Sum"]
     )
@@ -67,7 +67,7 @@ def a_matrix_to_html_table(
         pretty_format_numerical_iterable(
             (lifetime, *amps, amps.sum()), decimal_places=decimal_places
         )
-        for lifetime, amps in zip(lifetime, a_matrix.values)
+        for lifetime, amps in zip(lifetime, a_matrix.values, strict=True)
     ]
     data.append(
         pretty_format_numerical_iterable(

--- a/pyglotaran_extras/inspect/utils.py
+++ b/pyglotaran_extras/inspect/utils.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from collections.abc import Iterable
 
 
 def wrap_in_details_tag(

--- a/pyglotaran_extras/inspect/utils.py
+++ b/pyglotaran_extras/inspect/utils.py
@@ -19,13 +19,13 @@ def wrap_in_details_tag(
 
     Parameters
     ----------
-    details_content: str
+    details_content : str
         Markdown string that should be displayed when the details are expanded.
-    summary_content: str | None
+    summary_content : str | None
         Summary test that should be displayed. Defaults to None so the summary is ``Details``.
-    summary_heading_level: int | None
+    summary_heading_level : int | None
         Level of the heading wrapping the ``summary`` if it is not None. Defaults to None.
-    is_open: bool
+    is_open : bool
         Whether or not the details tag should be initially opened. Defaults to False.
 
     Returns
@@ -55,14 +55,14 @@ def pretty_format_numerical(value: float | int, decimal_places: int = 1) -> str:
 
     Used to format values like the t-value.
 
-    TODO: remove after raise pyglotaran dependency to 0.7.0
+    TODO : remove after raise pyglotaran dependency to 0.7.0
     Forward port of https://github.com/glotaran/pyglotaran/pull/1192
 
     Parameters
     ----------
-    value: float | int
+    value : float | int
         Numerical value to format.
-    decimal_places: int
+    decimal_places : int
         Decimal places to display. Defaults to 1.
 
     Returns
@@ -93,9 +93,9 @@ def pretty_format_numerical_iterable(
 
     Parameters
     ----------
-    input_values: Iterable[str  |  float]
+    input_values : Iterable[str | float]
         Values that should be formatted.
-    decimal_places: int | None
+    decimal_places : int | None
         Number of decimal places a value should have, if None the original value will be used.
         Defaults to 3.
 

--- a/pyglotaran_extras/io/load_data.py
+++ b/pyglotaran_extras/io/load_data.py
@@ -58,4 +58,5 @@ def load_data(
         return result.data[keys[0]]
     if isinstance(result, (str, Path)):
         return load_data(load_dataset(result))
-    raise TypeError(f"Result needs to be of type {DatasetConvertible!r}, but was {result!r}.")
+    msg = f"Result needs to be of type {DatasetConvertible!r}, but was {result!r}."
+    raise TypeError(msg)

--- a/pyglotaran_extras/io/load_data.py
+++ b/pyglotaran_extras/io/load_data.py
@@ -20,10 +20,10 @@ def load_data(
     ----------
     result : DatasetConvertible | Result
         Result class instance, xarray Dataset or path to a dataset file.
-    dataset_name : str, optional
+    dataset_name : str | None
         Name of a specific dataset contained in ``result``, if not provided
         the first dataset will be extracted. Defaults to None.
-    _stacklevel: int
+    _stacklevel : int
         Stacklevel of the warning which is raised when ``result`` is of class ``Result``,
         contains multiple datasets and no ``dataset_name`` is provided. Changing this value is
         only required if you use this function inside of another function. Defaults to 2

--- a/pyglotaran_extras/io/load_data.py
+++ b/pyglotaran_extras/io/load_data.py
@@ -56,7 +56,7 @@ def load_data(
                 stacklevel=_stacklevel,
             )
         return result.data[keys[0]]
-    if isinstance(result, (str, Path)):
+    if isinstance(result, str | Path):
         return load_data(load_dataset(result))
     msg = f"Result needs to be of type {DatasetConvertible!r}, but was {result!r}."
     raise TypeError(msg)

--- a/pyglotaran_extras/io/setup_case_study.py
+++ b/pyglotaran_extras/io/setup_case_study.py
@@ -21,7 +21,7 @@ def setup_case_study(
     ----------
     output_folder_name : str
         Name of the base folder for the results. Defaults to "pyglotaran_results".
-    results_folder_root : None
+    results_folder_root : None | str | PathLike[str]
         The folder where the results named ``output_folder_name`` should be saved to.
         Defaults to None, which results in the users Home folder being used.
 

--- a/pyglotaran_extras/io/setup_case_study.py
+++ b/pyglotaran_extras/io/setup_case_study.py
@@ -40,7 +40,7 @@ def setup_case_study(
             Folder the script or Notebook resides in.
     """
     analysis_folder = get_script_dir(nesting=1)
-    print(f"Setting up case study for folder: {analysis_folder}")
+    print(f"Setting up case study for folder: {analysis_folder}")  # noqa: T201
     if results_folder_root is None:
         results_folder_root = Path.home() / output_folder_name
     else:
@@ -48,7 +48,7 @@ def setup_case_study(
     script_folder_rel = analysis_folder.relative_to(analysis_folder.parent)
     results_folder = (results_folder_root / script_folder_rel).resolve()
     results_folder.mkdir(parents=True, exist_ok=True)
-    print(f"Results will be saved in: {results_folder}")
+    print(f"Results will be saved in: {results_folder}")  # noqa: T201
     return results_folder, analysis_folder.resolve()
 
 

--- a/pyglotaran_extras/io/setup_case_study.py
+++ b/pyglotaran_extras/io/setup_case_study.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import inspect
-from os import PathLike
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 
 def setup_case_study(

--- a/pyglotaran_extras/io/utils.py
+++ b/pyglotaran_extras/io/utils.py
@@ -35,7 +35,7 @@ def result_dataset_mapping(result: ResultLike) -> Mapping[str, xr.Dataset]:
     result_mapping = {}
     if isinstance(result, Result):
         return result.data
-    if isinstance(result, (xr.Dataset, xr.DataArray, Path, str)):
+    if isinstance(result, xr.Dataset | xr.DataArray | Path | str):
         return {"dataset": load_data(result)}
     if isinstance(result, Sequence):
         for index, value in enumerate(result):

--- a/pyglotaran_extras/io/utils.py
+++ b/pyglotaran_extras/io/utils.py
@@ -45,4 +45,5 @@ def result_dataset_mapping(result: ResultLike) -> Mapping[str, xr.Dataset]:
         for key, value in result.items():
             result_mapping[key] = load_data(value)
         return result_mapping
-    raise TypeError(f"Result needs to be of type {ResultLike!r}, but was {result!r}.")
+    msg = f"Result needs to be of type {ResultLike!r}, but was {result!r}."
+    raise TypeError(msg)

--- a/pyglotaran_extras/io/utils.py
+++ b/pyglotaran_extras/io/utils.py
@@ -22,7 +22,7 @@ def result_dataset_mapping(result: ResultLike) -> Mapping[str, xr.Dataset]:
 
     Returns
     -------
-    Mapping[str, Dataset]
+    Mapping[str, xr.Dataset]
         Per dataset mapping of result like data.
 
     Raises

--- a/pyglotaran_extras/plotting/plot_coherent_artifact.py
+++ b/pyglotaran_extras/plotting/plot_coherent_artifact.py
@@ -40,32 +40,32 @@ def plot_coherent_artifact(
 
     Parameters
     ----------
-    dataset: DatasetConvertible | Result
+    dataset : DatasetConvertible | Result
         Result dataset from a pyglotaran optimization.
-    time_range: tuple[float, float] | None
+    time_range : tuple[float, float] | None
         Start and end time for the IRF derivative plot. Defaults to None which means that
         the full time range is used.
-    spectral: float
+    spectral : float
         Value of the spectral axis that should be used to select the data for the IRF derivative
         plot this value does not need to be an exact existing value and only has effect if the
         IRF has dispersion. Defaults to 0 which means that the IRF derivative plot at lowest
         spectral value will be shown.
-    main_irf_nr: int | None
+    main_irf_nr : int | None
         Index of the main ``irf`` component when using an ``irf`` parametrized with multiple peaks
         and is used to shift the time axis. If it is none ``None`` the shifting will be
         deactivated. Defaults to 0.
-    normalize: bool
+    normalize : bool
         Whether or not to normalize the IRF derivative plot. If the IRF derivative is normalized,
         the IRFAS is scaled with the reciprocal of the normalization to compensate for this.
         Defaults to True.
-    figsize: tuple[float, float]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (18, 7).
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
-    cycler: Cycler | None
+    cycler : Cycler | None
         Plot style cycler to use. Defaults to None, which means that the matplotlib default style
         will be used.
-    title: str | None
+    title : str | None
         Title of the figure. Defaults to "Coherent Artifact".
 
     Returns

--- a/pyglotaran_extras/plotting/plot_concentrations.py
+++ b/pyglotaran_extras/plotting/plot_concentrations.py
@@ -29,30 +29,30 @@ def plot_concentrations(
 
     Parameters
     ----------
-    res: xr.Dataset
+    res : xr.Dataset
         Result dataset from a pyglotaran optimization.
-    ax: Axis
+    ax : Axis
         Axis to plot the traces on
-    center_λ: float | None
+    center_λ : float | None
         Center wavelength (λ in nm)
-    linlog: bool
+    linlog : bool
         Whether to use 'symlog' scale or not. Defaults to False.
-    linthresh: float
+    linthresh : float
         A single float which defines the range (-x, x), within which the plot is linear.
         This avoids having the plot go to infinity around zero. Defaults to 1.
-    linscale: float
+    linscale : float
         This allows the linear range (-linthresh to linthresh) to be stretched
         relative to the logarithmic range.
         Its value is the number of decades to use for each half of the linear range.
         For example, when linscale == 1.0 (the default), the space used for the
         positive and negative halves of the linear range will be equal to one
         decade in the logarithmic range. Defaults to 1.
-    main_irf_nr: int
+    main_irf_nr : int
         Index of the main ``irf`` component when using an ``irf``
         parametrized with multiple peaks. Defaults to 0.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
-    title: str
+    title : str
         Title used for the plot axis. Defaults to "Concentrations".
 
     See Also

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -64,7 +64,7 @@ def plot_data_overview(
 
     Returns
     -------
-    tuple[Figure, Axes] | tuple[Figure,Axis]
+    tuple[Figure, Axes] | tuple[Figure, Axis]
         Figure and axes which can then be refined by the user.
     """
     dataset = load_data(dataset, _stacklevel=3)

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -19,7 +19,7 @@ from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 __all__ = ["plot_data_overview"]
 
 if TYPE_CHECKING:
-    from typing import Hashable
+    from collections.abc import Hashable
 
     import xarray as xr
     from glotaran.project.result import Result

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -43,7 +43,7 @@ def plot_data_overview(
 
     Parameters
     ----------
-    dataset :  DatasetConvertible | Result
+    dataset : DatasetConvertible | Result
         Dataset containing data and SVD of the data.
     title : str
         Title to add to the figure. Defaults to "Data overview".
@@ -52,19 +52,19 @@ def plot_data_overview(
     linthresh : float
         A single float which defines the range (-x, x), within which the plot is linear.
         This avoids having the plot go to infinity around zero. Defaults to 1.
-    figsize : tuple[int, int]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (15, 10).
-    nr_of_data_svd_vectors: int
+    nr_of_data_svd_vectors : int
         Number of data SVD vector to plot. Defaults to 4.
-    show_data_svd_legend: bool
+    show_data_svd_legend : bool
         Whether or not to show the data SVD legend. Defaults to True.
-    irf_location:  float | None
+    irf_location : float | None
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
 
     Returns
     -------
-    tuple[Figure, Axes]|tuple[Figure,Axis]
+    tuple[Figure, Axes] | tuple[Figure,Axis]
         Figure and axes which can then be refined by the user.
     """
     dataset = load_data(dataset, _stacklevel=3)
@@ -127,18 +127,18 @@ def _plot_single_trace(
 
     Parameters
     ----------
-    data_array: xr.DataArray
+    data_array : xr.DataArray
         DataArray containing only data  of a single trace.
-    x_dim: Hashable
+    x_dim : Hashable
         Name of the x dimension.
-    title: str
+    title : str
         Title to add to the figure. Defaults to "Data overview".
-    linlog: bool
+    linlog : bool
         Whether to use 'symlog' scale or not. Defaults to False.
-    linthresh: float
+    linthresh : float
         A single float which defines the range (-x, x), within which the plot is linear.
         This avoids having the plot go to infinity around zero. Defaults to 1.
-    figsize: tuple[float, float]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (15, 10).
 
     Returns

--- a/pyglotaran_extras/plotting/plot_doas.py
+++ b/pyglotaran_extras/plotting/plot_doas.py
@@ -6,7 +6,6 @@ from typing import Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
-from cycler import Cycler
 
 from pyglotaran_extras.io.load_data import load_data
 from pyglotaran_extras.plotting.style import PlotStyle
@@ -17,6 +16,7 @@ from pyglotaran_extras.plotting.utils import extract_irf_location
 from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 
 if TYPE_CHECKING:
+    from cycler import Cycler
     from glotaran.project.result import Result
     from matplotlib.figure import Figure
     from matplotlib.pyplot import Axes

--- a/pyglotaran_extras/plotting/plot_doas.py
+++ b/pyglotaran_extras/plotting/plot_doas.py
@@ -43,39 +43,39 @@ def plot_doas(
 
     Parameters
     ----------
-    dataset: DatasetConvertible | Result
+    dataset : DatasetConvertible | Result
         Result dataset from a pyglotaran optimization.
-    damped_oscillation: list[str] | None
+    damped_oscillation : list[str] | None
         List of oscillation names which should be plotted.
         Defaults to None which means that all oscillations will be plotted.
-    time_range: tuple[float, float] | None
+    time_range : tuple[float, float] | None
         Start and end time for the Oscillation plot, if ``main_irf_nr`` is not None the value are
         relative to the IRF location. Defaults to None which means that the full time range is
         used.
-    spectral: float
+    spectral : float
         Value of the spectral axis that should be used to select the data for the Oscillation
         plot this value does not need to be an exact existing value and only has effect if the
         IRF has dispersion. Defaults to 0 which means that the Oscillation plot at lowest
         spectral value will be shown.
-    main_irf_nr: int | None
+    main_irf_nr : int | None
         Index of the main ``irf`` component when using an ``irf`` parametrized with multiple peaks
         and is used to shift the time axis. If it is none ``None`` the shifting will be
         deactivated. Defaults to 0.
-    normalize: bool
+    normalize : bool
         Whether or not to normalize the DOAS spectra plot. If the DOAS spectra is normalized,
         the Oscillation is scaled with the reciprocal of the normalization to compensate for this.
         Defaults to False.
-    figsize: tuple[float, float]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (20, 5)
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True
-    cycler: Cycler | None
+    cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler
-    oscillation_type: Literal["cos", "sin"]
+    oscillation_type : Literal["cos", "sin"]
         Type of the oscillation to show in the oscillation plot. Defaults to "cos"
-    title: str | None
+    title : str | None
         Title of the figure. Defaults to "Damped oscillations"
-    legend_format_string: str
+    legend_format_string : str
         Format string for each entry in the legend of the oscillation plot. Possible values which
         can be replaced are ``label`` (label of the oscillation in the model definition),
         ``frequency`` (ν) and ``rate`` (γ). Use ``""`` to remove the legend. Defaults to

--- a/pyglotaran_extras/plotting/plot_doas.py
+++ b/pyglotaran_extras/plotting/plot_doas.py
@@ -127,7 +127,7 @@ def plot_doas(
         **time_sel_kwargs
     )
 
-    for oscillation_label in oscillations_to_plot.damped_oscillation.values:
+    for oscillation_label in oscillations_to_plot.damped_oscillation.to_numpy():
         oscillation = oscillations_to_plot.sel(damped_oscillation=[oscillation_label])
         frequency = oscillation.damped_oscillation_frequency.item()
         rate = oscillation.damped_oscillation_rate.item()

--- a/pyglotaran_extras/plotting/plot_guidance.py
+++ b/pyglotaran_extras/plotting/plot_guidance.py
@@ -29,15 +29,15 @@ def plot_guidance(
 
     Parameters
     ----------
-    result: DatasetConvertible | Result
+    result : DatasetConvertible | Result
         Result from a pyglotaran optimization as dataset, Path or Result object.
-    figsize: tuple[float, float]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (15, 5)
-    title: str
+    title : str
         Title to add to the figure. Defaults to "Guidance Overview"
-    y_label: str
+    y_label : str
         Label used for the y-axis of each subplot. Defaults to "a.u."
-    cycler: Cycler | None
+    cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
 
     Returns

--- a/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
+++ b/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
@@ -7,6 +7,8 @@ from typing import cast
 
 import matplotlib.pyplot as plt
 import xarray as xr
+from matplotlib.axis import Axis
+from matplotlib.figure import Figure
 
 from pyglotaran_extras.io.utils import result_dataset_mapping
 from pyglotaran_extras.plotting.style import PlotStyle
@@ -17,8 +19,6 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from cycler import Cycler
-    from matplotlib.axis import Axis
-    from matplotlib.figure import Figure
 
     from pyglotaran_extras.types import ResultLike
 

--- a/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
+++ b/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
@@ -34,15 +34,15 @@ def plot_irf_dispersion_center(
 
     Parameters
     ----------
-    result: ResultLike
+    result : ResultLike
         Data structure which can be converted to a mapping.
     ax : Axis | None
         Axis to plot on. Defaults to None which means that a new figure and axis will be created.
-    figsize: tuple[float, float]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (12, 8).
-    cycler: Cycler
+    cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler
-    irf_location:  float | None
+    irf_location : float | None
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
 
@@ -89,17 +89,17 @@ def _plot_irf_dispersion_center(
 
     Parameters
     ----------
-    res: xr.Dataset
+    res : xr.Dataset
         Dataset containing the IRF data.
-    ax: Axis
+    ax : Axis
         Axis to plot on.
-    spectral_axis: Literal["x", "y"]
+    spectral_axis : Literal["x", "y"]
         Direct of the spectral axis in the plot. Defaults to "x"
-    cycler: Cycler | None
+    cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    label: str
+    label : str
         Plot label for the IRF shown in the legend. Defaults to "IRF"
-    irf_location:  float | None
+    irf_location : float | None
         Location of the ``irf`` by which the time axis (here values) will get shifted.
         If it is None the time axis will not be shifted. Defaults to None.
     """

--- a/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
+++ b/pyglotaran_extras/plotting/plot_irf_dispersion_center.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Tuple
 from typing import cast
 
 import matplotlib.pyplot as plt
@@ -54,7 +53,7 @@ def plot_irf_dispersion_center(
     """
     result_map = result_dataset_mapping(result)
     if ax is None:
-        fig, axis = cast(Tuple[Figure, Axis], plt.subplots(1, figsize=figsize))
+        fig, axis = cast(tuple[Figure, Axis], plt.subplots(1, figsize=figsize))
     else:
         axis = ax
     for dataset_name, dataset in result_map.items():

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -231,12 +231,12 @@ if __name__ == "__main__":
 
     result_path = Path(sys.argv[1])
     res = load_data(result_path)
-    print(res)
+    print(res)  # noqa: T201
 
     fig, axes = plot_overview(res)
     if len(sys.argv) > 2:
         fig.savefig(sys.argv[2], bbox_inches="tight")
-        print(f"Saved figure to: {sys.argv[2]}")
+        print(f"Saved figure to: {sys.argv[2]}")  # noqa: T201
     else:
         plt.show(block=False)
         input("press <ENTER> to continue")

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -53,46 +53,46 @@ def plot_overview(
 
     Parameters
     ----------
-    result: DatasetConvertible | Result
+    result : DatasetConvertible | Result
         Result from a pyglotaran optimization as dataset, Path or Result object.
-    center_λ: float | None
+    center_λ : float | None
         Center wavelength (λ in nm)
-    linlog: bool
+    linlog : bool
         Whether to use 'symlog' scale or not. Defaults to False.
-    linthresh: float
+    linthresh : float
         A single float which defines the range (-x, x), within which the plot is linear.
         This avoids having the plot go to infinity around zero. Defaults to 1.
-    linscale: float
+    linscale : float
         This allows the linear range (-linthresh to linthresh) to be stretched
         relative to the logarithmic range.
         Its value is the number of decades to use for each half of the linear range.
         For example, when linscale == 1.0 (the default), the space used for the
         positive and negative halves of the linear range will be equal to one
         decade in the logarithmic range. Defaults to 1.
-    show_data: bool | None
+    show_data : bool | None
         Whether to show the input data or residual. If set to ``None`` the plot is skipped
         which improves plotting performance for big datasets. Defaults to False.
-    main_irf_nr: int
+    main_irf_nr : int
         Index of the main ``irf`` component when using an ``irf``
         parametrized with multiple peaks. Defaults to 0.
-    figsize : tuple[int, int]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (18, 16).
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    figure_only: bool | None
+    figure_only : bool | None
         Deprecated please remove this argument for you function calls. Defaults to None.
-    nr_of_data_svd_vectors: int
+    nr_of_data_svd_vectors : int
         Number of data SVD vector to plot. Defaults to 4.
-    nr_of_residual_svd_vectors: int
+    nr_of_residual_svd_vectors : int
         Number of residual SVD vector to plot. Defaults to 2.
-    show_data_svd_legend: bool
+    show_data_svd_legend : bool
         Whether or not to show the data SVD legend. Defaults to True.
-    show_residual_svd_legend: bool
+    show_residual_svd_legend : bool
         Whether or not to show the residual SVD legend. Defaults to True.
-    show_irf_dispersion_center: bool
+    show_irf_dispersion_center : bool
         Whether to show the the IRF dispersion center as overlay on the residual/data plot.
         Defaults to True.
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero to the plots of the spectra.
         Defaults to True.
 
@@ -169,20 +169,20 @@ def plot_simple_overview(
 
     Parameters
     ----------
-    result: DatasetConvertible | Result
+    result : DatasetConvertible | Result
         Result from a pyglotaran optimization as dataset, Path or Result object.
-    title: str | None
+    title : str | None
         Title of the figure. Defaults to None.
-    figsize : tuple[int, int]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (18, 16).
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    figure_only: bool | None
+    figure_only : bool | None
         Deprecated please remove this argument for you function calls. Defaults to None.
-    show_irf_dispersion_center: bool
+    show_irf_dispersion_center : bool
         Whether to show the the IRF dispersion center as overlay on the residual/data plot.
         Defaults to True.
-    show_data: bool | None
+    show_data : bool | None
         Whether to show the input data or residual. If set to ``None`` the plot is skipped
         which improves plotting performance for big datasets. Defaults to False.
 

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -107,10 +107,7 @@ def plot_overview(
         if figure_only is not None:
             warn(PyglotaranExtrasApiDeprecationWarning(FIG_ONLY_WARNING), stacklevel=2)
         return fig, axes
-    # Plot dimensions
-    M = 4
-    N = 3
-    fig, axes = plt.subplots(M, N, figsize=figsize, constrained_layout=True)
+    fig, axes = plt.subplots(4, 3, figsize=figsize, constrained_layout=True)
 
     irf_location = extract_irf_location(res, center_λ, main_irf_nr)
 

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -161,7 +161,7 @@ def plot_simple_overview(
     figure_only: bool | None = None,
     show_irf_dispersion_center: bool = True,
     show_data: bool | None = False,
-) -> Figure | tuple[Figure, Axes]:
+) -> tuple[Figure, Axes]:
     """Plot simple overview.
 
     Parameters

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -102,7 +102,7 @@ def plot_overview(
     """
     res = load_data(result, _stacklevel=3)
 
-    if res.coords["time"].values.size == 1:
+    if res.coords["time"].to_numpy().size == 1:
         fig, axes = plot_guidance(res)
         if figure_only is not None:
             warn(PyglotaranExtrasApiDeprecationWarning(FIG_ONLY_WARNING), stacklevel=2)
@@ -198,10 +198,10 @@ def plot_simple_overview(
     if title:
         fig.suptitle(title, fontsize=16)
 
-    plot_concentrations(res, ax=axes[0, 0], center_λ=res.coords["spectral"].values[0])
+    plot_concentrations(res, ax=axes[0, 0], center_λ=res.coords["spectral"].to_numpy()[0])
     plot_sas(res, ax=axes[0, 1])
 
-    irf_location = extract_irf_location(res, center_λ=res.coords["spectral"].values[0])
+    irf_location = extract_irf_location(res, center_λ=res.coords["spectral"].to_numpy()[0])
 
     plot_lsv_residual(res, ax=axes[1, 0], irf_location=irf_location)
     plot_rsv_residual(res, ax=axes[1, 1])

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -40,15 +40,15 @@ def plot_residual(
     linthresh : float
         A single float which defines the range (-x, x), within which the plot is linear.
         This avoids having the plot go to infinity around zero. Defaults to 1.
-    show_data: bool | None
+    show_data : bool | None
         Whether to show the input data or residual. If set to ``None`` the plot is skipped
         which improves plotting performance for big datasets. Defaults to False.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_irf_dispersion_center: bool
+    show_irf_dispersion_center : bool
         Whether to show the the IRF dispersion center as overlay on the residual/data plot.
         Defaults to True.
-    irf_location:  float | None
+    irf_location : float | None
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
     """

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -31,7 +31,7 @@ def plot_spectra(
         Axes to plot the spectra on (needs to be at least 2x2).
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
     """
     plot_sas(res, axes[0, 0], cycler=cycler, show_zero_line=show_zero_line)
@@ -59,7 +59,7 @@ def plot_sas(
         Title of the plot. Defaults to "SAS".
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
@@ -94,7 +94,7 @@ def plot_norm_sas(
         Title of the plot. Defaults to "norm SAS".
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
@@ -130,7 +130,7 @@ def plot_das(
         Title of the plot. Defaults to "DAS".
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
@@ -165,7 +165,7 @@ def plot_norm_das(
         Title of the plot. Defaults to "norm DAS".
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -103,7 +103,6 @@ def plot_norm_sas(
     ]
     for key in keys:
         sas = res[key]
-        # sas = res.species_associated_spectra
         (sas / np.abs(sas).max(dim="spectral")).plot.line(x="spectral", ax=ax)
         ax.set_title(title)
         ax.get_legend().remove()

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -11,7 +11,7 @@ from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
 from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
 
 if TYPE_CHECKING:
-    from typing import Sequence
+    from collections.abc import Sequence
 
     import xarray as xr
     from cycler import Cycler

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -135,8 +135,8 @@ def plot_lsv_data(
         axis will not be shifted. Defaults to None.
     """
     add_cycler_if_not_none(ax, cycler)
-    dLSV = res.data_left_singular_vectors
-    dLSV = shift_time_axis_by_irf_location(dLSV, irf_location)
+    dLSV = res.data_left_singular_vectors  # noqa: N806
+    dLSV = shift_time_axis_by_irf_location(dLSV, irf_location)  # noqa: N806
     _plot_svd_vectors(dLSV, indices, "left_singular_value_index", ax, show_legend)
     ax.set_title("data. LSV")
     if linlog:
@@ -167,7 +167,7 @@ def plot_rsv_data(
         Whether or not to show the legend. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
-    dRSV = res.data_right_singular_vectors
+    dRSV = res.data_right_singular_vectors  # noqa: N806
     _plot_svd_vectors(dRSV, indices, "right_singular_value_index", ax, show_legend)
     ax.set_title("data. RSV")
 
@@ -192,7 +192,7 @@ def plot_sv_data(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     """
     add_cycler_if_not_none(ax, cycler)
-    dSV = res.data_singular_values
+    dSV = res.data_singular_values  # noqa: N806
     dSV.sel(singular_value_index=indices[: len(dSV.singular_value_index)]).plot.line(
         "ro-", yscale="log", ax=ax
     )
@@ -234,10 +234,10 @@ def plot_lsv_residual(
     """
     add_cycler_if_not_none(ax, cycler)
     if "weighted_residual_left_singular_vectors" in res:
-        rLSV = res.weighted_residual_left_singular_vectors
+        rLSV = res.weighted_residual_left_singular_vectors  # noqa: N806
     else:
-        rLSV = res.residual_left_singular_vectors
-    rLSV = shift_time_axis_by_irf_location(rLSV, irf_location)
+        rLSV = res.residual_left_singular_vectors  # noqa: N806
+    rLSV = shift_time_axis_by_irf_location(rLSV, irf_location)  # noqa: N806
     _plot_svd_vectors(rLSV, indices, "left_singular_value_index", ax, show_legend)
     ax.set_title("res. LSV")
     if linlog:
@@ -269,9 +269,9 @@ def plot_rsv_residual(
     """
     add_cycler_if_not_none(ax, cycler)
     if "weighted_residual_right_singular_vectors" in res:
-        rRSV = res.weighted_residual_right_singular_vectors
+        rRSV = res.weighted_residual_right_singular_vectors  # noqa: N806
     else:
-        rRSV = res.residual_right_singular_vectors
+        rRSV = res.residual_right_singular_vectors  # noqa: N806
     _plot_svd_vectors(rRSV, indices, "right_singular_value_index", ax, show_legend)
     ax.set_title("res. RSV")
 
@@ -297,9 +297,9 @@ def plot_sv_residual(
     """
     add_cycler_if_not_none(ax, cycler)
     if "weighted_residual_singular_values" in res:
-        rSV = res.weighted_residual_singular_values
+        rSV = res.weighted_residual_singular_values  # noqa: N806
     else:
-        rSV = res.residual_singular_values
+        rSV = res.residual_singular_values  # noqa: N806
     rSV.sel(singular_value_index=indices[: len(rSV.singular_value_index)]).plot.line(
         "ro-", yscale="log", ax=ax
     )

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -46,15 +46,15 @@ def plot_svd(
         This avoids having the plot go to infinity around zero. Defaults to 1.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    nr_of_data_svd_vectors: int
+    nr_of_data_svd_vectors : int
         Number of data SVD vector to plot. Defaults to 4.
-    nr_of_residual_svd_vectors: int
+    nr_of_residual_svd_vectors : int
         Number of residual SVD vector to plot. Defaults to 2.
-    show_data_svd_legend: bool
+    show_data_svd_legend : bool
         Whether or not to show the data SVD legend. Defaults to True.
-    show_residual_svd_legend: bool
+    show_residual_svd_legend : bool
         Whether or not to show the residual SVD legend. Defaults to True.
-    irf_location:  float | None
+    irf_location : float | None
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
     """
@@ -128,9 +128,9 @@ def plot_lsv_data(
         This avoids having the plot go to infinity around zero. Defaults to 1.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_legend: bool
+    show_legend : bool
         Whether or not to show the legend. Defaults to True.
-    irf_location:  float | None
+    irf_location : float | None
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
     """
@@ -163,7 +163,7 @@ def plot_rsv_data(
         Indices of the singular vector to plot. Defaults to range(4).
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_legend: bool
+    show_legend : bool
         Whether or not to show the legend. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
@@ -226,9 +226,9 @@ def plot_lsv_residual(
         This avoids having the plot go to infinity around zero. Defaults to 1.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_legend: bool
+    show_legend : bool
         Whether or not to show the legend. Defaults to True.
-    irf_location:  float | None
+    irf_location : float | None
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
     """
@@ -264,7 +264,7 @@ def plot_rsv_residual(
         Indices of the singular vector to plot. Defaults to range(4).
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
-    show_legend: bool
+    show_legend : bool
         Whether or not to show the legend. Defaults to True.
     """
     add_cycler_if_not_none(ax, cycler)
@@ -317,15 +317,15 @@ def _plot_svd_vectors(
 
     Parameters
     ----------
-    vector_data: xr.DataArray
+    vector_data : xr.DataArray
         DataArray containing the SVD vector data.
-    indices: Sequence[int]
+    indices : Sequence[int]
         Indices of the singular vector to plot.
-    sv_index_dim: str
+    sv_index_dim : str
         Name of the singular value index dimension.
-    ax: Axis
+    ax : Axis
         Axis to plot on.
-    show_legend: bool
+    show_legend : bool
         Whether or not to show the legend.
 
     See Also

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -187,7 +187,7 @@ def plot_sv_data(
     ax : Axis
         Axis to plot on.
     indices : Sequence[int]
-        Indices of the singular vector to plot. Defaults to range(4).
+        Indices of the singular vector to plot. Defaults to range(10).
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     """
@@ -291,7 +291,7 @@ def plot_sv_residual(
     ax : Axis
         Axis to plot on.
     indices : Sequence[int]
-        Indices of the singular vector to plot. Defaults to range(4).
+        Indices of the singular vector to plot. Defaults to range(10).
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     """
@@ -341,7 +341,7 @@ def _plot_svd_vectors(
     if x_dim == sv_index_dim:
         values = values.T
         x_dim = vector_data.dims[0]
-    for zorder, label, value in zip(range(100)[::-1], indices[:max_index], values):
+    for zorder, label, value in zip(range(100)[::-1], indices[:max_index], values, strict=False):
         value.plot.line(x=x_dim, ax=ax, zorder=zorder, label=label)
     if show_legend is True:
         ax.legend(title=sv_index_dim)

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -187,7 +187,7 @@ def plot_fitted_traces(
             ),
             stacklevel=2,
         )
-    for wavelength, axis in zip(wavelengths, axes.flatten()):
+    for wavelength, axis in zip(wavelengths, axes.flatten(), strict=True):
         plot_data_and_fits(
             result=result_map,
             wavelength=wavelength,

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -83,7 +83,7 @@ def plot_data_and_fits(
     """
     result_map = result_dataset_mapping(result)
     add_cycler_if_not_none(axis, cycler)
-    for dataset_name in result_map.keys():
+    for dataset_name in result_map:
         if result_map[dataset_name].coords["time"].to_numpy().size == 1:
             continue
         spectral_coords = result_map[dataset_name].coords["spectral"].to_numpy()
@@ -176,7 +176,7 @@ def plot_fitted_traces(
     fig, axes = plt.subplots(*axes_shape, figsize=figsize)
     nr_of_plots = len(axes.flatten())
     max_spectral_values = max(
-        len(result_map[dataset_name].coords["spectral"]) for dataset_name in result_map.keys()
+        len(result_map[dataset_name].coords["spectral"]) for dataset_name in result_map
     )
     if nr_of_plots > max_spectral_values:
         warn(

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -53,9 +53,9 @@ def plot_data_and_fits(
         Data structure which can be converted to a mapping.
     wavelength : float
         Wavelength to plot data and fits for.
-    axis: Axis
+    axis : Axis
         Axis to plot the data and fits on.
-    center_λ: float | None
+    center_λ : float | None
         Center wavelength (λ in nm)
     main_irf_nr : int
         Index of the main ``irf`` component when using an ``irf``
@@ -68,13 +68,13 @@ def plot_data_and_fits(
     divide_by_scale : bool
         Whether or not to divide the data by the dataset scale used for optimization.
         Defaults to True.
-    per_axis_legend: bool
+    per_axis_legend : bool
         Whether to use a legend per plot or for the whole figure. Defaults to False.
-    y_label: str
+    y_label : str
         Label used for the y-axis of each subplot.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
 
     See Also
@@ -128,12 +128,12 @@ def plot_fitted_traces(
     ----------
     result : ResultLike
         Data structure which can be converted to a mapping of datasets.
-    axes_shape : tuple[int, int]
-        Shape of the plot grid (N, M). Defaults to (4, 4).
-    wavelengths: Iterable[float]
+    wavelengths : Iterable[float]
         Wavelength which should be used for each subplot, should to be of length N*M
         with ``axes_shape`` being of shape (N, M), else it will result in missing plots.
-    center_λ: float | None
+    axes_shape : tuple[int, int]
+        Shape of the plot grid (N, M). Defaults to (4, 4).
+    center_λ : float | None
         Center wavelength of the IRF (λ in nm).
     main_irf_nr : int
         Index of the main ``irf`` component when using an ``irf``
@@ -148,15 +148,15 @@ def plot_fitted_traces(
         Defaults to True.
     per_axis_legend : bool
         Whether to use a legend per plot or for the whole figure. Defaults to False.
-    figsize : tuple[int, int]
+    figsize : tuple[float, float]
         Size of the figure (N, M) in inches. Defaults to (30, 15).
     title : str
         Title to add to the figure. Defaults to "Fit overview".
-    y_label: str
+    y_label : str
         Label used for the y-axis of each subplot.
     cycler : Cycler | None
         Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
-    show_zero_line: bool
+    show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
 
 

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -19,7 +19,7 @@ from pyglotaran_extras.plotting.utils import select_plot_wavelengths
 __all__ = ["select_plot_wavelengths", "plot_fitted_traces"]
 
 if TYPE_CHECKING:
-    from typing import Iterable
+    from collections.abc import Iterable
 
     from cycler import Cycler
     from matplotlib.axis import Axis

--- a/pyglotaran_extras/plotting/plot_traces.py
+++ b/pyglotaran_extras/plotting/plot_traces.py
@@ -84,9 +84,9 @@ def plot_data_and_fits(
     result_map = result_dataset_mapping(result)
     add_cycler_if_not_none(axis, cycler)
     for dataset_name in result_map.keys():
-        if result_map[dataset_name].coords["time"].values.size == 1:
+        if result_map[dataset_name].coords["time"].to_numpy().size == 1:
             continue
-        spectral_coords = result_map[dataset_name].coords["spectral"].values
+        spectral_coords = result_map[dataset_name].coords["spectral"].to_numpy()
         if spectral_coords.min() <= wavelength <= spectral_coords.max():
             result_data = result_map[dataset_name].sel(spectral=[wavelength], method="nearest")
             scale = extract_dataset_scale(result_data, divide_by_scale)

--- a/pyglotaran_extras/plotting/style.py
+++ b/pyglotaran_extras/plotting/style.py
@@ -128,7 +128,7 @@ class PlotStyle:
         self._line_style = list(LineStyle)
         self._color_codes = list(ColorCode)
         # Since Enum only supports unique values we need to manually add the last one
-        self._data_color_codes = list(DataColorCode) + [DataColorCode.orange]
+        self._data_color_codes = [*list(DataColorCode), DataColorCode.orange]
         # Extend linecycler to same size as colorcycler
         self._data_line_style = list(DataLineStyle) * (len(self._data_color_codes) // 2)
         self.SMALL_SIZE = 12

--- a/pyglotaran_extras/plotting/style.py
+++ b/pyglotaran_extras/plotting/style.py
@@ -1,6 +1,7 @@
 """Module containing predefined plot styles.
 
-For reference see: https://glotaran.github.io/legacy/plot_styles
+For reference see:
+https://glotaran.github.io/legacy/plot_styles
 """
 from __future__ import annotations
 
@@ -84,10 +85,9 @@ class LineStyle(str, Enum):
 class DataColorCode(str, Enum):
     """Colors used to plot data and fits.
 
-    Pairs of visually similar looking colors whereby the
-    first (lighter) color is used to plot the data,
-    and the second (darker) color is used to represent
-    the fitted trace (that goes 'through' the data).
+    Pairs of visually similar looking colors whereby the first (lighter) color is used to plot the
+    data, and the second (darker) color is used to represent the fitted trace (that goes 'through'
+    the data).
     """
 
     # Name	#Hex
@@ -112,8 +112,8 @@ class DataColorCode(str, Enum):
 class DataLineStyle(str, Enum):
     """Data plots can alternate between solid lines for data and dashed lines for fits.
 
-    This is mostly useful for data with very low noise (e.g. simulated data),
-    since data and fir often overlap
+    This is mostly useful for data with very low noise (e.g. simulated data), since data and fit
+    often overlap.
     """
 
     solid = "-"

--- a/pyglotaran_extras/plotting/style.py
+++ b/pyglotaran_extras/plotting/style.py
@@ -104,9 +104,8 @@ class DataColorCode(str, Enum):
     brown = "#964b00"
     maroon = "#800000"
     yellow = "#ffff00"
-    # Needs to be added manually to the list in PlotStyle
+    # Adding orange a second time needs to be added manually to the list in PlotStyle
     # since Enum doesn't allow duplicates
-    # orange = "#ff8c00"
 
 
 class DataLineStyle(str, Enum):

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -60,10 +60,11 @@ def select_irf_dispersion_center_by_index(
     """
     if "irf_nr" in irf_dispersion.sizes:
         if main_irf_nr >= irf_dispersion.sizes["irf_nr"]:
-            raise ValueError(
-                f"The value {main_irf_nr=} is not a valid value for "
-                f"irf_nr, needs to be smaller than {irf_dispersion.sizes['irf_nr']}."
+            msg = (
+                f"The value main_irf_nr={main_irf_nr!r} is not a valid value for irf_nr, needs "
+                f"to be smaller than {irf_dispersion.sizes['irf_nr']}."
             )
+            raise ValueError(msg)
         irf_dispersion = irf_dispersion.sel(irf_nr=main_irf_nr)
     if irf_dispersion.size == 1:
         irf_dispersion = irf_dispersion.item()
@@ -335,7 +336,8 @@ def shift_time_axis_by_irf_location(
         return plot_data
 
     if "time" not in plot_data.coords:
-        raise ValueError("plot_data need to have a 'time' axis.")
+        msg = "plot_data need to have a 'time' axis."
+        raise ValueError(msg)
 
     times_shifted = plot_data.coords["time"] - irf_location
     return plot_data.assign_coords(time=times_shifted)
@@ -371,7 +373,8 @@ def get_shifted_traces(
     elif "species_associated_concentrations" in res:
         traces = res.species_associated_concentrations
     else:
-        raise ValueError(f"No concentrations in result:\n{res}")
+        msg = f"No concentrations in result:\n{res}"
+        raise ValueError(msg)
 
     irf_location = extract_irf_location(res, center_λ, main_irf_nr)
     return shift_time_axis_by_irf_location(traces, irf_location)

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from math import ceil
 from math import log
 from types import MappingProxyType
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
-from typing import Iterable
 from warnings import warn
 
 import numpy as np
@@ -17,9 +17,9 @@ from pyglotaran_extras.io.utils import result_dataset_mapping
 
 if TYPE_CHECKING:
     from typing import Callable
-    from typing import Hashable
     from typing import Literal
     from typing import Mapping
+    from collections.abc import Hashable
 
     from cycler import Cycler
     from matplotlib.axis import Axis

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -112,7 +112,7 @@ def extract_irf_dispersion_center(
         irf_dispersion_center = min(res.coords["time"]).item()
 
     if as_dataarray is True:
-        spectral = res.coords["spectral"].values
+        spectral = res.coords["spectral"].to_numpy()
         return xr.DataArray(
             irf_dispersion_center * np.ones(spectral.shape), {"spectral": spectral}
         )
@@ -177,7 +177,7 @@ def maximum_coordinate_range(
     minima = []
     maxima = []
     for dataset in result_map.values():
-        coord = dataset.coords[coord_name].values
+        coord = dataset.coords[coord_name].to_numpy()
         minima.append(coord.min())
         maxima.append(coord.max())
     return min(minima), max(maxima)
@@ -271,7 +271,7 @@ def select_plot_wavelengths(
         (wavelength_range[0] <= spectral_coords) & (spectral_coords <= wavelength_range[1])
     ]
     spectral_indices = np.linspace(0, len(spectral_coords) - 1, num=nr_of_plots, dtype=np.int64)
-    return spectral_coords[spectral_indices].values
+    return spectral_coords[spectral_indices].to_numpy()
 
 
 def extract_dataset_scale(res: xr.Dataset, divide_by_scale: bool = True) -> float:

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -1,10 +1,10 @@
 """Module containing plotting utility functionality."""
 from __future__ import annotations
 
+from collections.abc import Iterable
 from math import ceil
 from math import log
 from types import MappingProxyType
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
 from warnings import warn
 
@@ -16,10 +16,10 @@ from pyglotaran_extras.inspect.utils import pretty_format_numerical_iterable
 from pyglotaran_extras.io.utils import result_dataset_mapping
 
 if TYPE_CHECKING:
-    from typing import Callable
-    from typing import Literal
-    from typing import Mapping
+    from collections.abc import Callable
     from collections.abc import Hashable
+    from collections.abc import Mapping
+    from typing import Literal
 
     from cycler import Cycler
     from matplotlib.axis import Axis
@@ -386,7 +386,7 @@ def ensure_axes_array(axes: Axis | Axes) -> Axes:
 
     Parameters
     ----------
-    axes: Axis | Axes
+    axes : Axis | Axes
         Axis or Axes to convert for API consistency.
 
     Returns
@@ -595,14 +595,14 @@ class MinorSymLogLocator(Locator):
 
         return self.raise_if_exceeds(np.array(minorlocs))
 
-    def tick_values(self, vmin: float, vmax: float) -> None:
-        """Return the values of the located ticks given **vmin** and **vmax** (not implemented).
+    def tick_values(self, _vmin: float, _vmax: float) -> None:
+        """Return the values of the located ticks given **_vmin** and **_vmax** (not implemented).
 
         Parameters
         ----------
-        vmin : float
+        _vmin : float
             Minimum value.
-        vmax : float
+        _vmax : float
             Maximum value.
 
         Raises
@@ -610,7 +610,8 @@ class MinorSymLogLocator(Locator):
         NotImplementedError
             Not used
         """
-        raise NotImplementedError(f"Cannot get tick locations for a {type(self)} type.")
+        msg = f"Cannot get tick locations for a {type(self)} type."
+        raise NotImplementedError(msg)
 
 
 def format_sub_plot_number_upper_case_letter(sub_plot_number: int, size: None | int = None) -> str:
@@ -673,7 +674,7 @@ BuiltinSubPlotLabelFormatFunctions: Mapping[
     str, Callable[[int, int | None], str]
 ] = MappingProxyType(
     {
-        "number": lambda x, y: f"{x}",
+        "number": lambda x, _: f"{x}",
         "upper_case_letter": format_sub_plot_number_upper_case_letter,
         "lower_case_letter": lambda x, y: format_sub_plot_number_upper_case_letter(x, y).lower(),
     }
@@ -689,7 +690,7 @@ def get_subplot_label_format_function(
 
     Parameters
     ----------
-    format_function : BuiltinSubPlotLabelFormatFunctionKey | Callable[[int, int  |  None], str]
+    format_function : BuiltinSubPlotLabelFormatFunctionKey | Callable[[int, int | None], str]
         Key ``BuiltinSubPlotLabelFormatFunctions`` to retrieve builtin function or user defined
         format function.
 

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -207,11 +207,11 @@ def add_unique_figure_legend(fig: Figure, axes: Axes) -> None:
         labels += ax_labels
     unique = [
         (handle, label)
-        for i, (handle, label) in enumerate(zip(handles, labels))
+        for i, (handle, label) in enumerate(zip(handles, labels, strict=True))
         if label not in labels[:i]
     ]
     unique.sort(key=lambda entry: entry[1])
-    fig.legend(*zip(*unique))
+    fig.legend(*zip(*unique, strict=True))
 
 
 def select_plot_wavelengths(
@@ -300,7 +300,8 @@ def extract_dataset_scale(res: xr.Dataset, divide_by_scale: bool = True) -> floa
                     "Diving data by dataset scales is only supported by results from "
                     "'pyglotaran>=0.5.0'. Please upgrade pyglotaran and recreate the "
                     "result to plot."
-                )
+                ),
+                stacklevel=2,
             )
     return scale
 

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -204,7 +204,11 @@ def add_unique_figure_legend(fig: Figure, axes: Axes) -> None:
         ax_handles, ax_labels = ax.get_legend_handles_labels()
         handles += ax_handles
         labels += ax_labels
-    unique = [(h, l) for i, (h, l) in enumerate(zip(handles, labels)) if l not in labels[:i]]
+    unique = [
+        (handle, label)
+        for i, (handle, label) in enumerate(zip(handles, labels))
+        if label not in labels[:i]
+    ]
     unique.sort(key=lambda entry: entry[1])
     fig.legend(*zip(*unique))
 

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -42,9 +42,9 @@ def select_irf_dispersion_center_by_index(
 
     Parameters
     ----------
-    irf_dispersion: xr.DataArray
+    irf_dispersion : xr.DataArray
         Data Variable from a result dataset which contains the IRF dispersion data.
-    main_irf_nr: int
+    main_irf_nr : int
         Index of the main ``irf`` component when using an ``irf``
         parametrized with multiple peaks. Defaults to 0.
 
@@ -77,12 +77,12 @@ def extract_irf_dispersion_center(
 
     Parameters
     ----------
-    res: xr.Dataset
+    res : xr.Dataset
         Result dataset from a pyglotaran optimization.
-    main_irf_nr: int
+    main_irf_nr : int
         Index of the main ``irf`` component when using an ``irf``
         parametrized with multiple peaks. Defaults to 0.
-    as_dataarray: bool
+    as_dataarray : bool
         Ensure that the returned data are xr.DataArray instead of a float, even if the
         dispersion is none existent or constant. Defaults to True
 
@@ -127,9 +127,9 @@ def extract_irf_location(
     ----------
     res : xr.Dataset
         Result dataset from a pyglotaran optimization.
-    center_λ: float | None
+    center_λ : float | None
         Center wavelength (λ in nm)
-    main_irf_nr : int
+    main_irf_nr : int | None
         Index of the main ``irf`` component when using an ``irf`` parametrized with multiple peaks.
         If it is none ``None`` the location will be 0. Defaults to 0.
 
@@ -219,15 +219,15 @@ def select_plot_wavelengths(
 
     Parameters
     ----------
-    result: ResultLike
+    result : ResultLike
         Data structure which can be converted to a mapping of datasets.
-    axes_shape: tuple[int, int]
+    axes_shape : tuple[int, int]
         Shape of the plot grid (N, M). Defaults to (4, 4).
-    wavelength_range: tuple[float, float]
+    wavelength_range : tuple[float, float] | None
         Tuple of minimum and maximum values to calculate the the wavelengths
         used for plotting. If not provided the values will be tetermined over all datasets.
         Defaults to None.
-    equidistant_wavelengths: bool
+    equidistant_wavelengths : bool
         Whether or not wavelengths should be selected based on equidistant values
         or equidistant indices (only supported for a single dataset).
         Since in general multiple datasets will have. Defaults to True.
@@ -308,9 +308,9 @@ def shift_time_axis_by_irf_location(
 
     Parameters
     ----------
-    plot_data: xr.DataArray
+    plot_data : xr.DataArray
         Data to plot.
-    irf_location:  float | None
+    irf_location : float | None
         Location of the ``irf``, if the value is None the original ``plot_data`` will be returned.
 
     Returns
@@ -344,11 +344,11 @@ def get_shifted_traces(
 
     Parameters
     ----------
-    res: xr.Dataset
+    res : xr.Dataset
         Result dataset from a pyglotaran optimization.
-    center_λ: float|None
+    center_λ : float | None
         Center wavelength (λ in nm). Defaults to None.
-    main_irf_nr: int
+    main_irf_nr : int
         Index of the main ``irf`` component when using an ``irf``
         parametrized with multiple peaks. Defaults to 0.
 
@@ -402,9 +402,9 @@ def add_cycler_if_not_none(axis: Axis | Axes, cycler: Cycler | None) -> None:
 
     Parameters
     ----------
-    axis: Axis | Axes
+    axis : Axis | Axes
         Axis to plot on.
-    cycler: Cycler | None
+    cycler : Cycler | None
         Plot style cycler to use.
     """
     if cycler is not None:
@@ -420,9 +420,9 @@ def abs_max(
 
     Parameters
     ----------
-    data: xr.DataArray
+    data : xr.DataArray
         Data for which the absolute maximum should be calculated.
-    result_dims: Hashable | Iterable[Hashable]
+    result_dims : Hashable | Iterable[Hashable]
         Dimensions of ``data`` which should be preserved and part of the resulting DataArray.
         Defaults to () which results in using the absolute maximum of all values.
 
@@ -444,9 +444,9 @@ def calculate_ticks_in_units_of_pi(
 
     Parameters
     ----------
-    values: np.ndarray
+    values : np.ndarray | xr.DataArray
         Values which the ticks should be calculated for.
-    step_size: float
+    step_size : float
         Step size of the ticks in units of pi. Defaults to 0.5
 
     Returns
@@ -499,7 +499,7 @@ def not_single_element_dims(data_array: xr.DataArray) -> list[Hashable]:
 
     Parameters
     ----------
-    data_array: xr.DataArray
+    data_array : xr.DataArray
         DataArray to check if it has only a single dimension.
 
     Returns

--- a/pyglotaran_extras/types.py
+++ b/pyglotaran_extras/types.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Literal
 from typing import TypeAlias
 
@@ -38,6 +37,6 @@ SubPlotLabelCoordStrs: TypeAlias = Literal[
     "polar",
 ]
 
-SubPlotLabelCoord: TypeAlias = Union[
-    SubPlotLabelCoordStrs, Tuple[SubPlotLabelCoordStrs, SubPlotLabelCoordStrs]
-]
+SubPlotLabelCoord: TypeAlias = (
+    SubPlotLabelCoordStrs | tuple[SubPlotLabelCoordStrs, SubPlotLabelCoordStrs]
+)

--- a/pyglotaran_extras/types.py
+++ b/pyglotaran_extras/types.py
@@ -1,7 +1,8 @@
 """Module containing type definitions."""
 from __future__ import annotations
 
-import sys
+from collections.abc import Mapping
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Literal
@@ -13,18 +14,11 @@ from typing import Union
 import xarray as xr
 from glotaran.project.result import Result
 
-if TYPE_CHECKING:
-    if sys.version_info < (3, 10):
-        from typing_extensions import TypeAlias
-    else:
-        from typing import TypeAlias
-
-
-DatasetConvertible = Union[xr.Dataset, xr.DataArray, str, Path]
+DatasetConvertible: TypeAlias = xr.Dataset | xr.DataArray | str | Path
 """Types of data which can be converted to a dataset."""
-ResultLike = Union[
-    Result, DatasetConvertible, Mapping[str, DatasetConvertible], Sequence[DatasetConvertible]
-]
+ResultLike: TypeAlias = (
+    Result | DatasetConvertible | Mapping[str, DatasetConvertible] | Sequence[DatasetConvertible]
+)
 """Result like data which can be converted to a per dataset mapping."""
 
 

--- a/pyglotaran_extras/types.py
+++ b/pyglotaran_extras/types.py
@@ -6,10 +6,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Literal
-from typing import Mapping
-from typing import Sequence
-from typing import Tuple
-from typing import Union
+from typing import TypeAlias
 
 import xarray as xr
 from glotaran.project.result import Result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ select = [
   "INP", # flake8-no-pep420
   "PIE", # flake8-pie
   "T20", # flake8-print
-  # "PT",  # flake8-pytest-style
+  "PT",  # flake8-pytest-style
   "RSE", # flake8-raise
   "RET", # flake8-return
   "SIM", # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ select = [
   "PTH", # flake8-use-pathlib
   "ERA", # eradicate
   "PD",  # pandas-vet
-  # "PGH", # pygrep-hooks
+  "PGH", # pygrep-hooks
   "NPY", # NumPy-specific
   "RUF", # Ruff-specific
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ select = [
   "YTT", # flake8-2020
   "BLE", # flake8-blind-except
   # # "FBT", # flake8-boolean-trap
-  # # "B",  # flake8-bugbear
+  "B",   # flake8-bugbear
   "C4",  # flake8-comprehensions
   "T10", # flake8-debugger
   "FA",  # flake8-future-annotations
@@ -129,7 +129,16 @@ select = [
   "RUF", # Ruff-specific
 ]
 
-ignore = ["D202", "D213", "D203", "ISC002", "RUF001", "RUF002", "RUF003"]
+ignore = [
+  "D202",
+  "D213",
+  "D203",
+  "ISC002",
+  "RUF001",
+  "RUF002",
+  "RUF003",
+  "B008",
+]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ select = [
   "C4",  # flake8-comprehensions
   "T10", # flake8-debugger
   "FA",  # flake8-future-annotations
-  # "EM",  # flake8-errmsg
+  "EM",  # flake8-errmsg
   "ISC", # flake8-implicit-str-concat
   "INP", # flake8-no-pep420
   "PIE", # flake8-pie

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ exclude = '''
 )/
 '''
 
+[tool.docformatter]
+black = true
+wrap-summaries = 99
+wrap-descriptions = 99
+
 [tool.isort]
 profile = "hug"
 src_paths = ["pyglotaran_extras"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,10 +126,10 @@ select = [
   # "PD", # pandas-vet
   # "PGH", # pygrep-hooks
   "NPY", # NumPy-specific
-  # "RUF", # Ruff-specific
+  "RUF", # Ruff-specific
 ]
 
-ignore = ["D202", "D213", "D203", "ISC002"]
+ignore = ["D202", "D213", "D203", "ISC002", "RUF001", "RUF002", "RUF003"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ select = [
   "ARG", # flake8-unused-arguments
   "PTH", # flake8-use-pathlib
   "ERA", # eradicate
-  # "PD", # pandas-vet
+  "PD",  # pandas-vet
   # "PGH", # pygrep-hooks
   "NPY", # NumPy-specific
   "RUF", # Ruff-specific

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ select = [
   # "TCH", # flake8-type-checking
   "ARG", # flake8-unused-arguments
   "PTH", # flake8-use-pathlib
-  # "ERA", # eradicate
+  "ERA", # eradicate
   # "PD", # pandas-vet
   # "PGH", # pygrep-hooks
   "NPY", # NumPy-specific

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,79 @@ style = 'numpy'
 exclude = '^(docs/|setup.py$|tests?/)'
 require-return-section-when-returning-none = false
 allow-init-docstring = true
+
+[tool.ruff]
+
+select = [
+  "E", # pycodestyle
+  "W", # pycodestyle
+  "C", # mccabe
+  "F", # pyflakes
+  # "UP",  # pyupgrade
+  # "D", # pydocstyle
+  # "N",   # pep8-naming
+  # "YTT", # flake8-2020
+  # "BLE", # flake8-blind-except
+  # # "FBT", # flake8-boolean-trap
+  # # "B",  # flake8-bugbear
+  # "C4",  # flake8-comprehensions
+  # "T10", # flake8-debugger
+  # "FA",  # flake8-future-annotations
+  # "EM",  # flake8-errmsg
+  # "ISC", # flake8-implicit-str-concat
+  # "INP", # flake8-no-pep420
+  # "PIE", # flake8-pie
+  # "T20", # flake8-print
+  # "PT",  # flake8-pytest-style
+  # "RSE", # flake8-raise
+  # "RET", # flake8-return
+  # "SIM", # flake8-simplify
+  # "TCH", # flake8-type-checking
+  # "ARG", # flake8-unused-arguments
+  # "PTH", # flake8-use-pathlib
+  # "ERA", # eradicate
+  # "PD",  # pandas-vet
+  # "PGH", # pygrep-hooks
+  # "NPY", # NumPy-specific
+  # "RUF", # Ruff-specific
+]
+
+ignore = ["D202", "ISC002"]
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".git-rewrite",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "__pypackages__",
+  "_build",
+  "buck-out",
+  "build",
+  "dist",
+  "node_modules",
+  "venv",
+  "docs/conf.py",
+]
+
+# Same as Black.
+line-length = 99
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Assume Python 3.10.
+target-version = "py310"
+
+[tool.ruff.per-file-ignores]
+"setup.py" = ["D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ select = [
   "C", # mccabe
   "F", # pyflakes
   # "UP",  # pyupgrade
-  # "D", # pydocstyle
+  "D", # pydocstyle
   # "N",   # pep8-naming
   # "YTT", # flake8-2020
   # "BLE", # flake8-blind-except
@@ -129,7 +129,7 @@ select = [
   # "RUF", # Ruff-specific
 ]
 
-ignore = ["D202", "ISC002"]
+ignore = ["D202", "D213", "D203", "ISC002"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,8 @@ select = [
   "C", # mccabe
   "F", # pyflakes
   # "UP",  # pyupgrade
-  "D", # pydocstyle
-  # "N",   # pep8-naming
+  "D",   # pydocstyle
+  "N",   # pep8-naming
   "YTT", # flake8-2020
   "BLE", # flake8-blind-except
   # # "FBT", # flake8-boolean-trap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ select = [
   "RSE", # flake8-raise
   "RET", # flake8-return
   "SIM", # flake8-simplify
-  # "TCH", # flake8-type-checking
+  "TCH", # flake8-type-checking
   "ARG", # flake8-unused-arguments
   "PTH", # flake8-use-pathlib
   "ERA", # eradicate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,16 +96,16 @@ allow-init-docstring = true
 [tool.ruff]
 
 select = [
-  "E", # pycodestyle
-  "W", # pycodestyle
-  "C", # mccabe
-  "F", # pyflakes
-  # "UP",  # pyupgrade
+  "E",   # pycodestyle
+  "W",   # pycodestyle
+  "C",   # mccabe
+  "F",   # pyflakes
+  "UP",  # pyupgrade
   "D",   # pydocstyle
   "N",   # pep8-naming
   "YTT", # flake8-2020
   "BLE", # flake8-blind-except
-  # # "FBT", # flake8-boolean-trap
+  # "FBT", # flake8-boolean-trap
   "B",   # flake8-bugbear
   "C4",  # flake8-comprehensions
   "T10", # flake8-debugger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,29 +103,29 @@ select = [
   # "UP",  # pyupgrade
   "D", # pydocstyle
   # "N",   # pep8-naming
-  # "YTT", # flake8-2020
-  # "BLE", # flake8-blind-except
+  "YTT", # flake8-2020
+  "BLE", # flake8-blind-except
   # # "FBT", # flake8-boolean-trap
   # # "B",  # flake8-bugbear
-  # "C4",  # flake8-comprehensions
-  # "T10", # flake8-debugger
-  # "FA",  # flake8-future-annotations
+  "C4",  # flake8-comprehensions
+  "T10", # flake8-debugger
+  "FA",  # flake8-future-annotations
   # "EM",  # flake8-errmsg
-  # "ISC", # flake8-implicit-str-concat
-  # "INP", # flake8-no-pep420
-  # "PIE", # flake8-pie
+  "ISC", # flake8-implicit-str-concat
+  "INP", # flake8-no-pep420
+  "PIE", # flake8-pie
   # "T20", # flake8-print
   # "PT",  # flake8-pytest-style
-  # "RSE", # flake8-raise
-  # "RET", # flake8-return
+  "RSE", # flake8-raise
+  "RET", # flake8-return
   # "SIM", # flake8-simplify
   # "TCH", # flake8-type-checking
-  # "ARG", # flake8-unused-arguments
-  # "PTH", # flake8-use-pathlib
+  "ARG", # flake8-unused-arguments
+  "PTH", # flake8-use-pathlib
   # "ERA", # eradicate
-  # "PD",  # pandas-vet
+  # "PD", # pandas-vet
   # "PGH", # pygrep-hooks
-  # "NPY", # NumPy-specific
+  "NPY", # NumPy-specific
   # "RUF", # Ruff-specific
 ]
 
@@ -168,3 +168,4 @@ target-version = "py310"
 
 [tool.ruff.per-file-ignores]
 "setup.py" = ["D"]
+"tests/*" = ["ARG001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,83 +16,6 @@ exclude = '''
 )/
 '''
 
-[tool.docformatter]
-black = true
-wrap-summaries = 99
-wrap-descriptions = 99
-
-[tool.isort]
-profile = "hug"
-src_paths = ["pyglotaran_extras"]
-include_trailing_comma = true
-line_length = 99
-known_first_party = ["pyglotaran_extras"]
-force_single_line = true
-remove_redundant_aliases = true
-
-[tool.interrogate]
-exclude = ["setup.py", "docs", "tests/*"]
-ignore-init-module = true
-fail-under = 100
-
-[tool.nbqa.addopts]
-flake8 = ["--extend-ignore=E402,F404"]
-
-
-[tool.coverage.run]
-branch = true
-include = ['pyglotaran_extras/*']
-omit = [
-  'setup.py',
-  'tests/*',
-  # comment the above line if you want to see if all tests did run
-]
-
-[tool.coverage.report]
-# Regexes for lines to exclude from consideration
-exclude_lines = [
-  # Have to re-enable the standard pragma
-  'pragma: no cover',
-
-  # Don't complain about missing debug-only code:
-  'def __repr__',
-  'if self\.debug',
-
-  # Don't complain if tests don't hit defensive assertion code:
-  'raise AssertionError',
-  'raise NotImplementedError',
-
-  # Don't complain if non-runnable code isn't run:
-  'if 0:',
-  'if __name__ == .__main__.:',
-  'if TYPE_CHECKING:',
-]
-
-[tool.mypy]
-ignore_missing_imports = true
-scripts_are_modules = true
-show_error_codes = true
-warn_unused_ignores = true
-no_implicit_optional = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-disallow_untyped_calls = true
-no_implicit_reexport = true
-warn_unused_configs = true
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_incomplete_defs = false
-disallow_untyped_defs = false
-
-# For now this is not use because pydoclint does not support toml when used with flake8
-[tool.pydoclint]
-skip-checking-short-docstrings = false
-style = 'numpy'
-exclude = '^(docs/|setup.py$|tests?/)'
-require-return-section-when-returning-none = false
-allow-init-docstring = true
-
 [tool.ruff]
 
 select = [
@@ -178,3 +101,80 @@ target-version = "py310"
 [tool.ruff.per-file-ignores]
 "setup.py" = ["D"]
 "tests/*" = ["ARG001"]
+
+[tool.isort]
+profile = "hug"
+src_paths = ["pyglotaran_extras"]
+include_trailing_comma = true
+line_length = 99
+known_first_party = ["pyglotaran_extras"]
+force_single_line = true
+remove_redundant_aliases = true
+
+[tool.coverage.run]
+branch = true
+include = ['pyglotaran_extras/*']
+omit = [
+  'setup.py',
+  'tests/*',
+  # comment the above line if you want to see if all tests did run
+]
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_lines = [
+  # Have to re-enable the standard pragma
+  'pragma: no cover',
+
+  # Don't complain about missing debug-only code:
+  'def __repr__',
+  'if self\.debug',
+
+  # Don't complain if tests don't hit defensive assertion code:
+  'raise AssertionError',
+  'raise NotImplementedError',
+
+  # Don't complain if non-runnable code isn't run:
+  'if 0:',
+  'if __name__ == .__main__.:',
+  'if TYPE_CHECKING:',
+]
+
+[tool.mypy]
+ignore_missing_imports = true
+scripts_are_modules = true
+show_error_codes = true
+warn_unused_ignores = true
+no_implicit_optional = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+disallow_untyped_calls = true
+no_implicit_reexport = true
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+[tool.docformatter]
+black = true
+wrap-summaries = 99
+wrap-descriptions = 99
+
+[tool.interrogate]
+exclude = ["setup.py", "docs", "tests/*"]
+ignore-init-module = true
+fail-under = 100
+
+[tool.nbqa.addopts]
+flake8 = ["--extend-ignore=E402,F404"]
+
+# For now this is not used because pydoclint does not support toml when used with flake8
+
+[tool.pydoclint]
+skip-checking-short-docstrings = false
+style = 'numpy'
+exclude = '^(docs/|setup.py$|tests?/)'
+require-return-section-when-returning-none = false
+allow-init-docstring = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,11 @@ warn_unused_configs = true
 module = "tests.*"
 disallow_incomplete_defs = false
 disallow_untyped_defs = false
+
+# For now this is not use because pydoclint does not support toml when used with flake8
+[tool.pydoclint]
+skip-checking-short-docstrings = false
+style = 'numpy'
+exclude = '^(docs/|setup.py$|tests?/)'
+require-return-section-when-returning-none = false
+allow-init-docstring = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ select = [
   "ISC", # flake8-implicit-str-concat
   "INP", # flake8-no-pep420
   "PIE", # flake8-pie
-  # "T20", # flake8-print
+  "T20", # flake8-print
   # "PT",  # flake8-pytest-style
   "RSE", # flake8-raise
   "RET", # flake8-return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ select = [
   # "PT",  # flake8-pytest-style
   "RSE", # flake8-raise
   "RET", # flake8-return
-  # "SIM", # flake8-simplify
+  "SIM", # flake8-simplify
   # "TCH", # flake8-type-checking
   "ARG", # flake8-unused-arguments
   "PTH", # flake8-use-pathlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,5 @@ include =
 [rstcheck]
 ignore_directives = autosummary
 
-[darglint]
-docstring_style = numpy
-ignore_regex = test_.+|.*dummy.*
-
 [pydocstyle]
 convention = numpy

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+"""Test suite for ``pyglotaran_extras``."""
 from pathlib import Path
 
 TEST_DATA = Path(__file__).parent / "data"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,8 @@ from dataclasses import replace
 
 import pytest
 from glotaran.optimization.optimize import optimize
-from glotaran.testing.simulated_data.parallel_spectral_decay import SCHEME as scheme_par
-from glotaran.testing.simulated_data.sequential_spectral_decay import SCHEME as scheme_seq
+from glotaran.testing.simulated_data.parallel_spectral_decay import SCHEME as SCHEME_PAR
+from glotaran.testing.simulated_data.sequential_spectral_decay import SCHEME as SCHEME_SEQ
 
 from pyglotaran_extras.io.setup_case_study import get_script_dir
 
@@ -24,12 +24,12 @@ def wrapped_get_script_dir():
 @pytest.fixture(scope="session")
 def result_parallel_spectral_decay():
     """Test result from ``glotaran.testing.simulated_data.parallel_spectral_decay``."""
-    scheme = replace(scheme_par, maximum_number_function_evaluations=1)
+    scheme = replace(SCHEME_PAR, maximum_number_function_evaluations=1)
     return optimize(scheme)
 
 
 @pytest.fixture(scope="session")
 def result_sequential_spectral_decay():
     """Test result from ``glotaran.testing.simulated_data.sequential_spectral_decay``."""
-    scheme = replace(scheme_seq, maximum_number_function_evaluations=1)
+    scheme = replace(SCHEME_SEQ, maximum_number_function_evaluations=1)
     return optimize(scheme)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+"""PyTest fixture and test helper definitions."""
 # isort: off
 # Hack around https://github.com/pydata/xarray/issues/7259 which also affects pyglotaran <= 0.7.0
 import numpy  # noqa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 """PyTest fixture and test helper definitions."""
 # isort: off
 # Hack around https://github.com/pydata/xarray/issues/7259 which also affects pyglotaran <= 0.7.0
-import numpy  # noqa
-import netCDF4  # noqa
+import numpy  # noqa: F401
+import netCDF4  # noqa: F401
 
 # isort: on
 
@@ -17,7 +17,7 @@ from pyglotaran_extras.io.setup_case_study import get_script_dir
 
 
 def wrapped_get_script_dir():
-    """Testfunction for calls to get_script_dir used inside of other functions."""
+    """Test function for calls to get_script_dir used inside of other functions."""
     return get_script_dir(nesting=1)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,11 +25,11 @@ def wrapped_get_script_dir():
 def result_parallel_spectral_decay():
     """Test result from ``glotaran.testing.simulated_data.parallel_spectral_decay``."""
     scheme = replace(scheme_par, maximum_number_function_evaluations=1)
-    yield optimize(scheme)
+    return optimize(scheme)
 
 
 @pytest.fixture(scope="session")
 def result_sequential_spectral_decay():
     """Test result from ``glotaran.testing.simulated_data.sequential_spectral_decay``."""
     scheme = replace(scheme_seq, maximum_number_function_evaluations=1)
-    yield optimize(scheme)
+    return optimize(scheme)

--- a/tests/deprecation/__init__.py
+++ b/tests/deprecation/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``pyglotaran_extras.deprecation``."""

--- a/tests/deprecation/test_deprecation_utils.py
+++ b/tests/deprecation/test_deprecation_utils.py
@@ -36,26 +36,24 @@ DEPRECATION_WARN_MESSAGE = (
 )
 
 
-@pytest.fixture
-def pyglotaran_extras_0_3_0(monkeypatch: MonkeyPatch):
+@pytest.fixture()
+def _pyglotaran_extras_0_3_0(monkeypatch: MonkeyPatch):
     """Mock pyglotaran_extras version to always be 0.3.0 for the test."""
     monkeypatch.setattr(
         pyglotaran_extras.deprecation.deprecation_utils,
         "pyglotaran_extras_version",
         lambda: "0.3.0",
     )
-    yield
 
 
-@pytest.fixture
-def pyglotaran_extras_1_0_0(monkeypatch: MonkeyPatch):
+@pytest.fixture()
+def _pyglotaran_extras_1_0_0(monkeypatch: MonkeyPatch):
     """Mock pyglotaran_extras version to always be 1.0.0 for the test."""
     monkeypatch.setattr(
         pyglotaran_extras.deprecation.deprecation_utils,
         "pyglotaran_extras_version",
         lambda: "1.0.0",
     )
-    yield
 
 
 def test_pyglotaran_extras_version():
@@ -64,13 +62,13 @@ def test_pyglotaran_extras_version():
 
 
 @pytest.mark.parametrize(
-    "version_str, expected",
-    (
+    ("version_str", "expected"),
+    [
         ("0.0.1", (0, 0, 1)),
         ("0.0.1.post", (0, 0, 1)),
         ("0.0.1-dev", (0, 0, 1)),
         ("0.0.1-dev.post", (0, 0, 1)),
-    ),
+    ],
 )
 def test_parse_version(version_str: str, expected: tuple[int, int, int]):
     """Valid version strings."""
@@ -79,7 +77,7 @@ def test_parse_version(version_str: str, expected: tuple[int, int, int]):
 
 @pytest.mark.parametrize(
     "version_str",
-    ("1", "0.1", "a.b.c"),
+    ["1", "0.1", "a.b.c"],
 )
 def test_parse_version_errors(version_str: str):
     """Invalid version strings."""
@@ -87,7 +85,7 @@ def test_parse_version_errors(version_str: str):
         parse_version(version_str)
 
 
-@pytest.mark.usefixtures("pyglotaran_extras_0_3_0")
+@pytest.mark.usefixtures("_pyglotaran_extras_0_3_0")
 def test_check_overdue_no_raise(monkeypatch: MonkeyPatch):
     """Current version smaller then drop_version."""
     check_overdue(
@@ -96,7 +94,7 @@ def test_check_overdue_no_raise(monkeypatch: MonkeyPatch):
     )
 
 
-@pytest.mark.usefixtures("pyglotaran_extras_1_0_0")
+@pytest.mark.usefixtures("_pyglotaran_extras_1_0_0")
 def test_check_overdue_raises(monkeypatch: MonkeyPatch):
     """Current version is equal or bigger than drop_version."""
     with pytest.raises(OverDueDeprecation) as excinfo:
@@ -108,7 +106,7 @@ def test_check_overdue_raises(monkeypatch: MonkeyPatch):
     assert str(excinfo.value) == OVERDUE_ERROR_MESSAGE
 
 
-@pytest.mark.usefixtures("pyglotaran_extras_0_3_0")
+@pytest.mark.usefixtures("_pyglotaran_extras_0_3_0")
 def test_warn_deprecated():
     """Warning gets shown when all is in order."""
     with pytest.warns(PyglotaranExtrasApiDeprecationWarning) as record:
@@ -123,7 +121,7 @@ def test_warn_deprecated():
         assert Path(record[0].filename) == Path(__file__)
 
 
-@pytest.mark.usefixtures("pyglotaran_extras_1_0_0")
+@pytest.mark.usefixtures("_pyglotaran_extras_1_0_0")
 def test_warn_deprecated_overdue_deprecation(monkeypatch: MonkeyPatch):
     """Current version is equal or bigger than drop_version."""
 

--- a/tests/deprecation/test_deprecation_utils.py
+++ b/tests/deprecation/test_deprecation_utils.py
@@ -81,7 +81,7 @@ def test_parse_version(version_str: str, expected: tuple[int, int, int]):
     ("1", "0.1", "a.b.c"),
 )
 def test_parse_version_errors(version_str: str):
-    """Invalid version strings"""
+    """Invalid version strings."""
     with pytest.raises(ValueError, match=f"'{version_str}'"):
         parse_version(version_str)
 

--- a/tests/deprecation/test_deprecation_utils.py
+++ b/tests/deprecation/test_deprecation_utils.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import pyglotaran_extras
-from pyglotaran_extras.deprecation.deprecation_utils import OverDueDeprecation
+from pyglotaran_extras.deprecation.deprecation_utils import OverDueDeprecationError
 from pyglotaran_extras.deprecation.deprecation_utils import PyglotaranExtrasApiDeprecationWarning
 from pyglotaran_extras.deprecation.deprecation_utils import check_overdue
 from pyglotaran_extras.deprecation.deprecation_utils import parse_version
@@ -97,7 +97,7 @@ def test_check_overdue_no_raise(monkeypatch: MonkeyPatch):
 @pytest.mark.usefixtures("_pyglotaran_extras_1_0_0")
 def test_check_overdue_raises(monkeypatch: MonkeyPatch):
     """Current version is equal or bigger than drop_version."""
-    with pytest.raises(OverDueDeprecation) as excinfo:
+    with pytest.raises(OverDueDeprecationError) as excinfo:
         check_overdue(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
             to_be_removed_in_version="0.6.0",
@@ -125,7 +125,7 @@ def test_warn_deprecated():
 def test_warn_deprecated_overdue_deprecation(monkeypatch: MonkeyPatch):
     """Current version is equal or bigger than drop_version."""
 
-    with pytest.raises(OverDueDeprecation) as excinfo:
+    with pytest.raises(OverDueDeprecationError) as excinfo:
         warn_deprecated(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
             new_qual_name_usage=NEW_QUAL_NAME,
@@ -144,7 +144,7 @@ def test_warn_deprecated_no_overdue_deprecation_on_dev(monkeypatch: MonkeyPatch)
         lambda: "0.6.0-dev",
     )
 
-    with pytest.raises(OverDueDeprecation):
+    with pytest.raises(OverDueDeprecationError):
         warn_deprecated(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
             new_qual_name_usage=NEW_QUAL_NAME,

--- a/tests/deprecation/test_deprecation_utils.py
+++ b/tests/deprecation/test_deprecation_utils.py
@@ -1,3 +1,4 @@
+"""Tests for ``pyglotaran_extras.deprecation.deprecation_utils``."""
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/inspect/test_a_matrix.py
+++ b/tests/inspect/test_a_matrix.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize(
-    "kwargs, compare_file_suffix",
-    (
+    ("kwargs", "compare_file_suffix"),
+    [
         ({}, "default"),
         ({"normalize_initial_concentration": True}, "normalized"),
         ({"decimal_places": 2}, "decimal_2"),
-    ),
+    ],
 )
 def test_a_matrix_to_html_table(
     result_parallel_spectral_decay: Result, kwargs: dict[str, Any], compare_file_suffix: str
@@ -38,14 +38,14 @@ def test_a_matrix_to_html_table(
 
 
 @pytest.mark.parametrize(
-    "kwargs, compare_file_suffix",
-    (
+    ("kwargs", "compare_file_suffix"),
+    [
         ({}, "default"),
         ({"normalize_initial_concentration": True}, "normalized"),
         ({"decimal_places": 2}, "decimal_2"),
         ({"expanded_datasets": ("dataset_2",)}, "expanded_dataset_2"),
         ({"heading_offset": 0}, "heading_offset_0"),
-    ),
+    ],
 )
 def test_show_a_matrixes(
     result_parallel_spectral_decay: Result,

--- a/tests/inspect/test_a_matrix.py
+++ b/tests/inspect/test_a_matrix.py
@@ -1,15 +1,18 @@
 """Tests for ``pyglotaran_extras.inspect.a_matrix``."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Any
 
 import pytest
 import xarray as xr
-from glotaran.project import Result
 from tests import TEST_DATA
 
 from pyglotaran_extras.inspect.a_matrix import a_matrix_to_html_table
 from pyglotaran_extras.inspect.a_matrix import show_a_matrixes
+
+if TYPE_CHECKING:
+    from glotaran.project import Result
 
 
 @pytest.mark.parametrize(

--- a/tests/inspect/test_utils.py
+++ b/tests/inspect/test_utils.py
@@ -161,6 +161,6 @@ def test_pretty_format_numerical(value: float, decimal_places: int, expected: st
     ),
 )
 def test_pretty_format_numerical_iterable(decimal_places: int, expected: Iterable[str | float]):
-    """Values correct formatted"""
+    """Values correct formatted."""
     values = ("Foo", 1, 0.009, -1.0000000000000002, np.nan, np.inf)
     assert list(pretty_format_numerical_iterable(values, decimal_places)) == expected

--- a/tests/inspect/test_utils.py
+++ b/tests/inspect/test_utils.py
@@ -1,8 +1,8 @@
 """Tests for ``pyglotaran_extras.inspect.utils``."""
 from __future__ import annotations
 
-from collections.abc import Iterable
 from textwrap import dedent
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -10,6 +10,9 @@ import pytest
 from pyglotaran_extras.inspect.utils import pretty_format_numerical
 from pyglotaran_extras.inspect.utils import pretty_format_numerical_iterable
 from pyglotaran_extras.inspect.utils import wrap_in_details_tag
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @pytest.mark.parametrize(

--- a/tests/inspect/test_utils.py
+++ b/tests/inspect/test_utils.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize(
-    "details_content, summary_content, summary_heading_level,is_open,expected",
-    (
+    ("details_content", "summary_content", "summary_heading_level", "is_open", "expected"),
+    [
         pytest.param(
             "FOO",
             None,
@@ -101,7 +101,7 @@ if TYPE_CHECKING:
             ),
             id="defaults with heading summary",
         ),
-    ),
+    ],
 )
 def test_wrap_in_details_tag(
     details_content: str,
@@ -123,8 +123,8 @@ def test_wrap_in_details_tag(
 
 
 @pytest.mark.parametrize(
-    "value, decimal_places, expected",
-    (
+    ("value", "decimal_places", "expected"),
+    [
         (0.00000001, 1, "1.0e-08"),
         (-0.00000001, 1, "-1.0e-08"),
         (0.1, 1, "0.1"),
@@ -143,7 +143,7 @@ def test_wrap_in_details_tag(
         (np.nan, 1, "nan"),
         (np.inf, 1, "inf"),
         (-np.inf, 1, "-inf"),
-    ),
+    ],
 )
 def test_pretty_format_numerical(value: float, decimal_places: int, expected: str):
     """Pretty format values depending on decimal_places to show.
@@ -157,11 +157,11 @@ def test_pretty_format_numerical(value: float, decimal_places: int, expected: st
 
 
 @pytest.mark.parametrize(
-    "decimal_places, expected",
-    (
+    ("decimal_places", "expected"),
+    [
         (None, ["Foo", 1, 0.009, -1.0000000000000002, np.nan, np.inf]),
         (2, ["Foo", "1", "9.00e-03", "-1", "nan", "inf"]),
-    ),
+    ],
 )
 def test_pretty_format_numerical_iterable(decimal_places: int, expected: Iterable[str | float]):
     """Values correct formatted."""

--- a/tests/io/__init__.py
+++ b/tests/io/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``pyglotaran_extras.io``."""

--- a/tests/io/test_load_data.py
+++ b/tests/io/test_load_data.py
@@ -89,6 +89,7 @@ def test_load_data(
         load_data([1, 2])
 
     assert str(excinfo.value) == (
-        "Result needs to be of type typing.Union[xarray.core.dataset.Dataset, "
-        "xarray.core.dataarray.DataArray, str, pathlib.Path], but was [1, 2]."
+        "Result needs to be of type "
+        "xarray.core.dataset.Dataset | xarray.core.dataarray.DataArray | str | pathlib.Path, "
+        "but was [1, 2]."
     )

--- a/tests/io/test_setup_case_study.py
+++ b/tests/io/test_setup_case_study.py
@@ -16,21 +16,21 @@ if TYPE_CHECKING:
 
 
 def test_get_script_dir():
-    """Called directly"""
+    """Called directly."""
     expected = Path(__file__).parent
 
     assert get_script_dir() == expected
 
 
 def test_get_script_dir_in_closure():
-    """Called inside other function imported from different file"""
+    """Called inside other function imported from different file."""
     expected = Path(__file__).parent
 
     assert wrapped_get_script_dir() == expected
 
 
 def test_get_script_dir_tmp_path(tmp_path: Path):
-    """File in temp folder"""
+    """File in temp folder."""
     tmp_file = tmp_path / "foo.py"
     content = dedent(
         """
@@ -49,7 +49,7 @@ def test_get_script_dir_tmp_path(tmp_path: Path):
 
 
 def test_setup_case_study(monkeypatch: MonkeyPatch, tmp_path: Path):
-    """Default settings"""
+    """Default settings."""
     mock_home = tmp_path / "home"
     monkeypatch.setattr(Path, "home", lambda: mock_home)
 
@@ -62,7 +62,7 @@ def test_setup_case_study(monkeypatch: MonkeyPatch, tmp_path: Path):
 
 
 def test_setup_case_study_custom(tmp_path: Path):
-    """Custom settings"""
+    """Custom settings."""
     results_folder_root = tmp_path / "foo"
 
     results_folder, script_folder = setup_case_study(

--- a/tests/io/test_setup_case_study.py
+++ b/tests/io/test_setup_case_study.py
@@ -1,3 +1,4 @@
+"""Tests for ``pyglotaran_extras.io.setup_case_study``."""
 from __future__ import annotations
 
 import subprocess

--- a/tests/plotting/__init__.py
+++ b/tests/plotting/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for pyglotaran_extras.plotting"""
+"""Tests for pyglotaran_extras.plotting."""

--- a/tests/plotting/test_utils.py
+++ b/tests/plotting/test_utils.py
@@ -1,4 +1,4 @@
-"""Tests for pyglotaran_extras.plotting.utils"""
+"""Tests for pyglotaran_extras.plotting.utils."""
 from __future__ import annotations
 
 from typing import Hashable
@@ -32,7 +32,7 @@ DEFAULT_CYCLER = plt.rcParams["axes.prop_cycle"]
     ((None, DEFAULT_CYCLER()), (PlotStyle().cycler, PlotStyle().cycler())),
 )
 def test_add_cycler_if_not_none_single_axis(cycler: Cycler | None, expected_cycler: cycle):
-    """Default cycler if None and cycler otherwise on a single axis"""
+    """Default cycler if None and cycler otherwise on a single axis."""
     ax = plt.subplot()
     add_cycler_if_not_none(ax, cycler)
 
@@ -46,7 +46,7 @@ def test_add_cycler_if_not_none_single_axis(cycler: Cycler | None, expected_cycl
     ((None, DEFAULT_CYCLER()), (PlotStyle().cycler, PlotStyle().cycler())),
 )
 def test_add_cycler_if_not_none_multiple_axes(cycler: Cycler | None, expected_cycler: cycle):
-    """Default cycler if None and cycler otherwise on all axes"""
+    """Default cycler if None and cycler otherwise on all axes."""
     _, axes = plt.subplots(1, 2)
     add_cycler_if_not_none(axes, cycler)
 

--- a/tests/plotting/test_utils.py
+++ b/tests/plotting/test_utils.py
@@ -2,9 +2,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Hashable
-from typing import Iterable
-from typing import Literal
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -20,14 +17,16 @@ from pyglotaran_extras.plotting.utils import calculate_ticks_in_units_of_pi
 from pyglotaran_extras.plotting.utils import ensure_axes_array
 from pyglotaran_extras.plotting.utils import format_sub_plot_number_upper_case_letter
 from pyglotaran_extras.plotting.utils import not_single_element_dims
-from pyglotaran_extras.types import SubPlotLabelCoord
 
 if TYPE_CHECKING:
     from collections.abc import Hashable
     from collections.abc import Iterable
+    from typing import Literal
 
     from cycler import Cycler
     from cycler import cycle
+
+    from pyglotaran_extras.types import SubPlotLabelCoord
 
 matplotlib.use("Agg")
 DEFAULT_CYCLER = plt.rcParams["axes.prop_cycle"]
@@ -120,7 +119,7 @@ def test_not_single_element_dims(data_array: xr.DataArray, expected: list[Hashab
 
 @pytest.mark.parametrize(
     ("value", "size", "expected"),
-    (
+    [
         (1, None, "A"),
         (2, None, "B"),
         (26, None, "Z"),
@@ -132,7 +131,7 @@ def test_not_single_element_dims(data_array: xr.DataArray, expected: list[Hashab
         (26**2, 26**2, "ZZ"),
         (1, 26**3, "AAA"),
         (26**3, 26**3, "ZZZ"),
-    ),
+    ],
 )
 def test_format_sub_plot_number_upper_case_letter(value: int, size: int | None, expected: str):
     """Expected string format."""
@@ -165,11 +164,11 @@ def test_add_subplot_labels_defaults():
 
 
 @pytest.mark.parametrize(
-    "direction, expected", (("row", ["1", "2", "3", "4"]), ("column", ["1", "3", "2", "4"]))
+    ("direction", "expected"), [("row", ["1", "2", "3", "4"]), ("column", ["1", "3", "2", "4"])]
 )
-@pytest.mark.parametrize("label_position", ((0.01, 0.95), (-0.1, 1.0)))
-@pytest.mark.parametrize("label_coords", ("data", ("axes fraction", "data")))
-@pytest.mark.parametrize("fontsize", (12, 26))
+@pytest.mark.parametrize("label_position", [(0.01, 0.95), (-0.1, 1.0)])
+@pytest.mark.parametrize("label_coords", ["data", ("axes fraction", "data")])
+@pytest.mark.parametrize("fontsize", [12, 26])
 def test_add_subplot_labels_assignment(
     direction: Literal["row", "column"],
     label_position: tuple[float, float],
@@ -198,7 +197,7 @@ def test_add_subplot_labels_assignment(
     plt.close()
 
 
-@pytest.mark.parametrize("label_format_template, expected", (("{})", "1)"), ("({})", "(1)")))
+@pytest.mark.parametrize(("label_format_template", "expected"), [("{})", "1)"), ("({})", "(1)")])
 def test_add_subplot_labels_label_format_template(label_format_template: str, expected: str):
     """Template is used."""
     _, ax = plt.subplots(1, 1)

--- a/tests/plotting/test_utils.py
+++ b/tests/plotting/test_utils.py
@@ -31,8 +31,8 @@ DEFAULT_CYCLER = plt.rcParams["axes.prop_cycle"]
 
 
 @pytest.mark.parametrize(
-    "cycler,expected_cycler",
-    ((None, DEFAULT_CYCLER()), (PlotStyle().cycler, PlotStyle().cycler())),
+    ("cycler", "expected_cycler"),
+    [(None, DEFAULT_CYCLER()), (PlotStyle().cycler, PlotStyle().cycler())],
 )
 def test_add_cycler_if_not_none_single_axis(cycler: Cycler | None, expected_cycler: cycle):
     """Default cycler if None and cycler otherwise on a single axis."""
@@ -45,8 +45,8 @@ def test_add_cycler_if_not_none_single_axis(cycler: Cycler | None, expected_cycl
 
 
 @pytest.mark.parametrize(
-    "cycler,expected_cycler",
-    ((None, DEFAULT_CYCLER()), (PlotStyle().cycler, PlotStyle().cycler())),
+    ("cycler", "expected_cycler"),
+    [(None, DEFAULT_CYCLER()), (PlotStyle().cycler, PlotStyle().cycler())],
 )
 def test_add_cycler_if_not_none_multiple_axes(cycler: Cycler | None, expected_cycler: cycle):
     """Default cycler if None and cycler otherwise on all axes."""
@@ -60,8 +60,8 @@ def test_add_cycler_if_not_none_multiple_axes(cycler: Cycler | None, expected_cy
 
 
 @pytest.mark.parametrize(
-    "result_dims, expected",
-    (
+    ("result_dims", "expected"),
+    [
         ((), xr.DataArray(40)),
         ("dim1", xr.DataArray([20, 40], coords={"dim1": [1, 2]})),
         ("dim2", xr.DataArray([30, 40], coords={"dim2": [3, 4]})),
@@ -70,7 +70,7 @@ def test_add_cycler_if_not_none_multiple_axes(cycler: Cycler | None, expected_cy
             ("dim1", "dim2"),
             xr.DataArray([[10, 20], [30, 40]], coords={"dim1": [1, 2], "dim2": [3, 4]}),
         ),
-    ),
+    ],
 )
 def test_abs_max(result_dims: Hashable | Iterable[Hashable], expected: xr.DataArray):
     """Result values are positive and dimensions are preserved if result_dims is not empty."""
@@ -79,11 +79,11 @@ def test_abs_max(result_dims: Hashable | Iterable[Hashable], expected: xr.DataAr
 
 
 @pytest.mark.parametrize(
-    "step_size, expected_tick_values,expected_tick_labels",
-    (
+    ("step_size", "expected_tick_values", "expected_tick_labels"),
+    [
         (0.5, np.linspace(-np.pi, 2 * np.pi, num=7), ["-1", "-0.5", "0", "0.5", "1", "1.5", "2"]),
         (1, np.linspace(-np.pi, 2 * np.pi, num=4), ["-1", "0", "1", "2"]),
-    ),
+    ],
 )
 def test_calculate_ticks_in_units_of_pi(
     step_size: float, expected_tick_values: list[float], expected_tick_labels: list[str]
@@ -97,8 +97,8 @@ def test_calculate_ticks_in_units_of_pi(
 
 
 @pytest.mark.parametrize(
-    "data_array, expected",
-    (
+    ("data_array", "expected"),
+    [
         (xr.DataArray([1]), []),
         (xr.DataArray([1], coords={"dim1": [1]}), []),
         (xr.DataArray([[1], [1]], coords={"dim1": [1, 2], "dim2": [1]}), ["dim1"]),
@@ -108,7 +108,7 @@ def test_calculate_ticks_in_units_of_pi(
             ),
             ["dim1", "dim3"],
         ),
-    ),
+    ],
 )
 def test_not_single_element_dims(data_array: xr.DataArray, expected: list[Hashable]):
     """Only get dim with more than one element."""

--- a/tests/plotting/test_utils.py
+++ b/tests/plotting/test_utils.py
@@ -1,6 +1,7 @@
 """Tests for pyglotaran_extras.plotting.utils."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import Hashable
 from typing import Iterable
 from typing import Literal
@@ -10,8 +11,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import xarray as xr
-from cycler import Cycler
-from cycler import cycle
 
 from pyglotaran_extras.plotting.style import PlotStyle
 from pyglotaran_extras.plotting.utils import abs_max
@@ -22,6 +21,10 @@ from pyglotaran_extras.plotting.utils import ensure_axes_array
 from pyglotaran_extras.plotting.utils import format_sub_plot_number_upper_case_letter
 from pyglotaran_extras.plotting.utils import not_single_element_dims
 from pyglotaran_extras.types import SubPlotLabelCoord
+
+if TYPE_CHECKING:
+    from cycler import Cycler
+    from cycler import cycle
 
 matplotlib.use("Agg")
 DEFAULT_CYCLER = plt.rcParams["axes.prop_cycle"]

--- a/tests/plotting/test_utils.py
+++ b/tests/plotting/test_utils.py
@@ -23,6 +23,9 @@ from pyglotaran_extras.plotting.utils import not_single_element_dims
 from pyglotaran_extras.types import SubPlotLabelCoord
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
+    from collections.abc import Iterable
+
     from cycler import Cycler
     from cycler import cycle
 


### PR DESCRIPTION
This PR updates the tooling to use [ruff](https://github.com/astral-sh/ruff) instead of multiple tools

Have a look at the [ruff docs for an explanation of all the rules](https://beta.ruff.rs/docs/rules/)

### Change summary

- 🧰✨ Added docformatter to pre-commit
- 🧹 Formatted docstrings
- 🧰👌 Replaced darglint with pydoclint
- 🩹 Fixed docstring issues
- 🧰✨ Added actionlint to pre-commit
- 🧰👌 Replaced flake8 with ruff 
- 👌 Activated D ruff rule and fixed violations 
- 👌 Fix E741 (Ambiguous variable name: l) Error
- 👌 Activated YTT, BLE, C4, T10, FA, ISC, INP, PIE, RSE, RET, ARG, PTH,… 
- 👌 Activated RUF ruff rule and fixed violations
- 👌 Activated ERA ruff rule and fixed violations
- 👌 Activated EM ruff rule and fixed violations
- 👌 Activated PD ruff rule and fixed violations
- 👌 Activated SIM ruff rule and fixed violations
- 👌 Activated TCH ruff rule and fixed violations
- 👌 Activated T20 ruff rule and fixed violations
- 👌 Activated PT ruff rule and fixed violations
- 👌 Activated PGH ruff rule and fixed violations
- 👌 Activated N ruff rule and fixed violations
- 👌 Activated B ruff rule and fixed violations
- 👌 Activated UP ruff rule, fixed violations and removed pyupgrade hook
- 🧹 Removed yesqa hook since this is handeled by RUF007 
- 🧰 Pin and update pydoclint
- 🧹 Updated pre-commit config and fixed issues
- 🧰⬆️ Update pydoclint from 0.0.10 to 0.0.16 and fixed issues
- 🩹🧪 Fix exception test to use new typing syntax
- 🧹 Use modern typing after rebase
- 🧰⬆️ Update pre-commit config to use latest versions

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)