### PR TITLE
🩹 Fix crash when plotting spectral model result

### DIFF
--- a/pyglotaran_extras/plotting/plot_coherent_artifact.py
+++ b/pyglotaran_extras/plotting/plot_coherent_artifact.py
@@ -88,7 +88,9 @@ def plot_coherent_artifact(
         return fig, axes
 
     irf_location = extract_irf_location(dataset, spectral, main_irf_nr)
-    irf_data = shift_time_axis_by_irf_location(dataset.coherent_artifact_response, irf_location)
+    irf_data = shift_time_axis_by_irf_location(
+        dataset.coherent_artifact_response, irf_location, _internal_call=True
+    )
 
     irf_max = abs_max(irf_data, result_dims=("coherent_artifact_order"))
     irfas_max = abs_max(

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -68,7 +68,7 @@ def plot_data_overview(
         Figure and axes which can then be refined by the user.
     """
     dataset = load_data(dataset, _stacklevel=3)
-    data = shift_time_axis_by_irf_location(dataset.data, irf_location)
+    data = shift_time_axis_by_irf_location(dataset.data, irf_location, _internal_call=True)
 
     if len(not_single_element_dims(data)) == 1:
         return _plot_single_trace(

--- a/pyglotaran_extras/plotting/plot_doas.py
+++ b/pyglotaran_extras/plotting/plot_doas.py
@@ -111,7 +111,7 @@ def plot_doas(
         oscillations = oscillations.sel(spectral=spectral, method="nearest")
 
     oscillations = shift_time_axis_by_irf_location(
-        oscillations.sel(**osc_sel_kwargs), irf_location
+        oscillations.sel(**osc_sel_kwargs), irf_location, _internal_call=True
     )
     oscillations_spectra = dataset["damped_oscillation_associated_spectra"].sel(**osc_sel_kwargs)
 

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -65,7 +65,7 @@ def plot_residual(
 
     add_cycler_if_not_none(ax, cycler)
     data = res.data if show_data else res.residual
-    data = shift_time_axis_by_irf_location(data, irf_location)
+    data = shift_time_axis_by_irf_location(data, irf_location, _internal_call=True)
     title = "dataset" if show_data else "residual"
     shape = np.array(data.shape)
     # Handle different dimensionality of data

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -307,8 +307,7 @@ def extract_dataset_scale(res: xr.Dataset, divide_by_scale: bool = True) -> floa
 
 
 def shift_time_axis_by_irf_location(
-    plot_data: xr.DataArray,
-    irf_location: float | None,
+    plot_data: xr.DataArray, irf_location: float | None, *, _internal_call: bool = False
 ) -> xr.DataArray:
     """Shift ``plot_data`` 'time' axis  by the position of the main ``irf``.
 
@@ -318,6 +317,9 @@ def shift_time_axis_by_irf_location(
         Data to plot.
     irf_location : float | None
         Location of the ``irf``, if the value is None the original ``plot_data`` will be returned.
+    _internal_call : bool
+        This indicates internal use stripping away user help and silently skipping execution.
+        Defaults to False.
 
     Returns
     -------
@@ -333,7 +335,7 @@ def shift_time_axis_by_irf_location(
     --------
     extract_irf_location
     """
-    if irf_location is None:
+    if irf_location is None or ("time" not in plot_data.coords and _internal_call is True):
         return plot_data
 
     if "time" not in plot_data.coords:


### PR DESCRIPTION
This change fixes that high-level plot functions crash if the result data do not have a `time` axis (e.g. for a spectral model) and should be fully backwards compatible.
This is just a hotfix since it does not implement fully correct behavior for results from a spectral models (e.g. which plot to apply `linlog` to).
But properly handling non kinetic models will be left for a follow up PR.

### Change summary

- [🩹 Fix crash when plotting spectral model result](https://github.com/glotaran/pyglotaran-extras/commit/f4ea1577e6ddd96c9e38d75107e26869344a01b2)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)