### PR TITLE
🧰 Use black-pre-commit-mirror for 2x speedup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: absolufy-imports
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.0
+    rev: 23.9.1
     hooks:
       - id: black
         language_version: python3
@@ -90,7 +90,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.287
+    rev: v0.0.289
     hooks:
       - id: ruff
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,8 +32,8 @@ repos:
     hooks:
       - id: absolufy-imports
 
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.0
     hooks:
       - id: black
         language_version: python3
@@ -111,7 +111,7 @@ repos:
         additional_dependencies: [pydoclint==0.1.4]
 
   - repo: https://github.com/rstcheck/rstcheck
-    rev: "v6.1.2"
+    rev: "v6.2.0"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]


### PR DESCRIPTION
[See latest black release](https://github.com/psf/black/releases/tag/23.9.0)

> Black now has an
[official pre-commit mirror](https://github.com/psf/black-pre-commit-mirror). Swapping
https://github.com/psf/black to https://github.com/psf/black-pre-commit-mirror in
your .pre-commit-config.yaml will make Black about 2x faster (https://github.com/psf/black/pull/3828)

### Change summary

- [🧰 Use black-pre-commit-mirror for 2x speedup](https://github.com/glotaran/pyglotaran-extras/commit/03efc26c392b761e2955b5d4a62f4c8896a16a92)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)