### PR TITLE
👌 Use weighted residual instead of residual plots if present

### DIFF
--- a/pyglotaran_extras/plotting/plot_guidance.py
+++ b/pyglotaran_extras/plotting/plot_guidance.py
@@ -53,7 +53,10 @@ def plot_guidance(
 
     res.data.plot(x="spectral", ax=axes[0], label="data")
     res.fitted_data.plot(x="spectral", ax=axes[0], label="fit")
-    res.residual.plot(x="spectral", ax=axes[1], label="residual")
+    if "weighted_residual" in res:
+        res.weighted_residual.plot(x="spectral", ax=axes[1], label="weighted_residual")
+    else:
+        res.residual.plot(x="spectral", ax=axes[1], label="residual")
 
     for axis in axes:
         axis.set_ylabel(y_label)

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -64,9 +64,21 @@ def plot_residual(
         return
 
     add_cycler_if_not_none(ax, cycler)
-    data = res.data if show_data else res.weighted_residual if "weighted_residual" in res else res.residual
+    data = (
+        res.data
+        if show_data
+        else res.weighted_residual
+        if "weighted_residual" in res
+        else res.residual
+    )
     data = shift_time_axis_by_irf_location(data, irf_location, _internal_call=True)
-    title = "dataset" if show_data else "weighted residual" if "weighted_residual" in res else "residual"
+    title = (
+        "dataset"
+        if show_data
+        else "weighted residual"
+        if "weighted_residual" in res
+        else "residual"
+    )
     shape = np.array(data.shape)
     # Handle different dimensionality of data
     if min(shape) == 1:

--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -64,9 +64,9 @@ def plot_residual(
         return
 
     add_cycler_if_not_none(ax, cycler)
-    data = res.data if show_data else res.residual
+    data = res.data if show_data else res.weighted_residual if "weighted_residual" in res else res.residual
     data = shift_time_axis_by_irf_location(data, irf_location, _internal_call=True)
-    title = "dataset" if show_data else "residual"
+    title = "dataset" if show_data else "weighted residual" if "weighted_residual" in res else "residual"
     shape = np.array(data.shape)
     # Handle different dimensionality of data
     if min(shape) == 1:


### PR DESCRIPTION
If the weighted residual is present in the result we should show it instead of the unweighted residual.

### Change summary

- [if weighted_residual then plot it](https://github.com/glotaran/pyglotaran-extras/commit/67cec7c163489ed34c3b7840c5f31b482b02df68)
- [👌 Also use weighted_residual in plot_guidance if present](https://github.com/glotaran/pyglotaran-extras/commit/a1a699d8dec94e9c5b169c2f3eda3f0b3cb3e1df)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)