### PR TITLE
👌 Add color map arguments to plot_data_overview

### DIFF
--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -37,7 +37,9 @@ def plot_data_overview(
     figsize: tuple[float, float] = (15, 10),
     nr_of_data_svd_vectors: int = 4,
     show_data_svd_legend: bool = True,
-    irf_location: float | None = None,
+    irf_location: float | None = None,cmap='PuRd',
+    datamin: float | None = None,datamax: float | None = None,
+    model_label: str = "Time (ps)", global_label: str = "Wavelength (nm)"
 ) -> tuple[Figure, Axes] | tuple[Figure, Axis]:
     """Plot data as filled contour plot and SVD components.
 
@@ -61,6 +63,16 @@ def plot_data_overview(
     irf_location : float | None
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
+    cmap : str
+        Colormap to use for the filled contour plot. Defaults to "PuRd" (which is most suitable for emission data).
+    datamin: float | None = None
+        minimum of the data. Defaults to None.
+    datamax: float | None = None
+        maximum of the data. Defaults to None.
+    model_label: str
+        Axes label for model axis. Defaults to "Time (ps)".
+    global_label: str
+        Axes label for model axis. Defaults to "Wavelength (nm)".
 
     Returns
     -------
@@ -88,7 +100,7 @@ def plot_data_overview(
     rsv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 2), fig=fig))
 
     if len(data.time) > 1:
-        data.plot(x="time", ax=data_ax, center=False)
+        data.plot(x="time", ax=data_ax, center=False,cmap=cmap,vmin=datamin,vmax=datamax)
     else:
         data.plot(ax=data_ax)
 
@@ -104,6 +116,13 @@ def plot_data_overview(
     )
     plot_sv_data(dataset, sv_ax)
     plot_rsv_data(dataset, rsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=False)
+    sv_ax.set_ylabel("")
+    lsv_ax.set_ylabel("")
+    rsv_ax.set_ylabel("")
+    lsv_ax.set_xlabel(model_label)
+    rsv_ax.set_xlabel(global_label)
+    data_ax.set_xlabel(model_label)
+    data_ax.set_ylabel(global_label)
     if show_data_svd_legend is True:
         rsv_ax.legend(title="singular value index", loc="lower right", bbox_to_anchor=(1.13, 1))
     fig.suptitle(title, fontsize=16)

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -41,8 +41,6 @@ def plot_data_overview(
     cmap: str = "PuRd",
     datamin: float | None = None,
     datamax: float | None = None,
-    model_label: str = "Time (ps)",
-    global_label: str = "Wavelength (nm)",
 ) -> tuple[Figure, Axes] | tuple[Figure, Axis]:
     """Plot data as filled contour plot and SVD components.
 
@@ -73,10 +71,6 @@ def plot_data_overview(
         minimum of the data. Defaults to None.
     datamax : float | None
         maximum of the data. Defaults to None.
-    model_label : str
-        Axes label for model axis. Defaults to "Time (ps)".
-    global_label : str
-        Axes label for model axis. Defaults to "Wavelength (nm)".
 
     Returns
     -------
@@ -120,13 +114,6 @@ def plot_data_overview(
     )
     plot_sv_data(dataset, sv_ax)
     plot_rsv_data(dataset, rsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=False)
-    sv_ax.set_ylabel("")
-    lsv_ax.set_ylabel("")
-    rsv_ax.set_ylabel("")
-    lsv_ax.set_xlabel(model_label)
-    rsv_ax.set_xlabel(global_label)
-    data_ax.set_xlabel(model_label)
-    data_ax.set_ylabel(global_label)
     if show_data_svd_legend is True:
         rsv_ax.legend(title="singular value index", loc="lower right", bbox_to_anchor=(1.13, 1))
     fig.suptitle(title, fontsize=16)

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -37,9 +37,12 @@ def plot_data_overview(
     figsize: tuple[float, float] = (15, 10),
     nr_of_data_svd_vectors: int = 4,
     show_data_svd_legend: bool = True,
-    irf_location: float | None = None,cmap='PuRd',
-    datamin: float | None = None,datamax: float | None = None,
-    model_label: str = "Time (ps)", global_label: str = "Wavelength (nm)"
+    irf_location: float | None = None,
+    cmap: str = "PuRd",
+    datamin: float | None = None,
+    datamax: float | None = None,
+    model_label: str = "Time (ps)",
+    global_label: str = "Wavelength (nm)",
 ) -> tuple[Figure, Axes] | tuple[Figure, Axis]:
     """Plot data as filled contour plot and SVD components.
 
@@ -64,14 +67,15 @@ def plot_data_overview(
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
     cmap : str
-        Colormap to use for the filled contour plot. Defaults to "PuRd" (which is most suitable for emission data).
-    datamin: float | None = None
+        Colormap to use for the filled contour plot. Defaults to "PuRd" (which is most suitable
+        for emission data).
+    datamin : float | None
         minimum of the data. Defaults to None.
-    datamax: float | None = None
+    datamax : float | None
         maximum of the data. Defaults to None.
-    model_label: str
+    model_label : str
         Axes label for model axis. Defaults to "Time (ps)".
-    global_label: str
+    global_label : str
         Axes label for model axis. Defaults to "Wavelength (nm)".
 
     Returns
@@ -100,7 +104,7 @@ def plot_data_overview(
     rsv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 2), fig=fig))
 
     if len(data.time) > 1:
-        data.plot(x="time", ax=data_ax, center=False,cmap=cmap,vmin=datamin,vmax=datamax)
+        data.plot(x="time", ax=data_ax, center=False, cmap=cmap, vmin=datamin, vmax=datamax)
     else:
         data.plot(ax=data_ax)
 

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -39,8 +39,8 @@ def plot_data_overview(
     show_data_svd_legend: bool = True,
     irf_location: float | None = None,
     cmap: str = "PuRd",
-    datamin: float | None = None,
-    datamax: float | None = None,
+    vmin: float | None = None,
+    vmax: float | None = None,
 ) -> tuple[Figure, Axes] | tuple[Figure, Axis]:
     """Plot data as filled contour plot and SVD components.
 
@@ -65,12 +65,12 @@ def plot_data_overview(
         Location of the ``irf`` by which the time axis will get shifted. If it is None the time
         axis will not be shifted. Defaults to None.
     cmap : str
-        Colormap to use for the filled contour plot. Defaults to "PuRd" (which is most suitable
-        for emission data).
-    datamin : float | None
-        minimum of the data. Defaults to None.
-    datamax : float | None
-        maximum of the data. Defaults to None.
+        Colormap to use for the filled contour plot. Defaults to "PuRd" which is most suitable
+        for emission data (previous default was "viridis").
+    vmin : float | None
+        Lower value to anchor the colormap. Defaults to None meaning it inferred from the data.
+    vmax : float | None
+        Lower value to anchor the colormap. Defaults to None meaning it inferred from the data.
 
     Returns
     -------
@@ -98,7 +98,7 @@ def plot_data_overview(
     rsv_ax = cast(Axis, plt.subplot2grid((4, 3), (3, 2), fig=fig))
 
     if len(data.time) > 1:
-        data.plot(x="time", ax=data_ax, center=False, cmap=cmap, vmin=datamin, vmax=datamax)
+        data.plot(x="time", ax=data_ax, center=False, cmap=cmap, vmin=vmin, vmax=vmax)
     else:
         data.plot(ax=data_ax)
 


### PR DESCRIPTION
This change adds the ability to set the colormap and its range in `plot_data_overview`.

### Change summary

- 👌 Add colormap related arguments `cmap`, `vmin` and `vmax` to `plot_data_overview` to pass down to plot method ([See Also](https://docs.xarray.dev/en/latest/generated/xarray.plot.pcolormesh.html#xarray.plot.pcolormesh))

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)