### PR TITLE
👌 Add das_cycler and svd_cycler to plot collection functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@
 
 ## 0.8.0 (Unreleased)
 
+- 🧰👌 Switch tooling to ruff (#197)
+- 🩹 Fix crash when plotting spectral model result (#200)
+- 👷♻️ Use hatch as build backend (#204)
+- 🧰 Use black-pre-commit-mirror for 2x speedup (#205)
+- 🧰🚀 Use ruff for formatting (#214)
+- 👌 Use weighted residual instead of residual plots if present (#216)
+- 👌 Add color map arguments to plot_data_overview (#217)
+- 👌 Add das_cycler and svd_cycler to plot collection functions (#218)
+
 (changes-0_7_1)=
 
 ## 0.7.1 (2023-07-27)

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -12,6 +12,7 @@ from pyglotaran_extras.io.load_data import load_data
 from pyglotaran_extras.plotting.plot_svd import plot_lsv_data
 from pyglotaran_extras.plotting.plot_svd import plot_rsv_data
 from pyglotaran_extras.plotting.plot_svd import plot_sv_data
+from pyglotaran_extras.plotting.style import PlotStyle
 from pyglotaran_extras.plotting.utils import MinorSymLogLocator
 from pyglotaran_extras.plotting.utils import not_single_element_dims
 from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Hashable
 
     import xarray as xr
+    from cycler import Cycler
     from glotaran.project.result import Result
     from matplotlib.figure import Figure
     from matplotlib.pyplot import Axes
@@ -41,6 +43,7 @@ def plot_data_overview(
     cmap: str = "PuRd",
     vmin: float | None = None,
     vmax: float | None = None,
+    svd_cycler: Cycler | None = PlotStyle().cycler,
 ) -> tuple[Figure, Axes] | tuple[Figure, Axis]:
     """Plot data as filled contour plot and SVD components.
 
@@ -71,6 +74,8 @@ def plot_data_overview(
         Lower value to anchor the colormap. Defaults to None meaning it inferred from the data.
     vmax : float | None
         Lower value to anchor the colormap. Defaults to None meaning it inferred from the data.
+    svd_cycler : Cycler | None
+        Plot style cycler to use for SVD plots. Defaults to ``PlotStyle().cycler``.
 
     Returns
     -------
@@ -111,9 +116,16 @@ def plot_data_overview(
         linlog=linlog,
         linthresh=linthresh,
         irf_location=irf_location,
+        cycler=svd_cycler,
     )
     plot_sv_data(dataset, sv_ax)
-    plot_rsv_data(dataset, rsv_ax, indices=range(nr_of_data_svd_vectors), show_legend=False)
+    plot_rsv_data(
+        dataset,
+        rsv_ax,
+        indices=range(nr_of_data_svd_vectors),
+        show_legend=False,
+        cycler=svd_cycler,
+    )
     if show_data_svd_legend is True:
         rsv_ax.legend(title="singular value index", loc="lower right", bbox_to_anchor=(1.13, 1))
     fig.suptitle(title, fontsize=16)

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from pyglotaran_extras.plotting.style import PlotStyle
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
+from pyglotaran_extras.types import Unset
 
 if TYPE_CHECKING:
     import xarray as xr
@@ -14,12 +15,15 @@ if TYPE_CHECKING:
     from matplotlib.axis import Axis
     from matplotlib.pyplot import Axes
 
+    from pyglotaran_extras.types import UnsetType
+
 
 def plot_spectra(
     res: xr.Dataset,
     axes: Axes,
     cycler: Cycler | None = PlotStyle().cycler,
     show_zero_line: bool = True,
+    das_cycler: Cycler | None | UnsetType = Unset,
 ) -> None:
     """Plot spectra such as SAS and DAS as well as their normalize version on ``axes``.
 
@@ -33,11 +37,17 @@ def plot_spectra(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
+    das_cycler : Cycler | None | UnsetType
+        Plot style cycler to use for DAS plots. Defaults to ``Unset`` which means that the value
+        of ``cycler`` is used.
     """
+    if das_cycler is Unset:
+        das_cycler = cycler
+
     plot_sas(res, axes[0, 0], cycler=cycler, show_zero_line=show_zero_line)
-    plot_das(res, axes[0, 1], cycler=cycler, show_zero_line=show_zero_line)
+    plot_das(res, axes[0, 1], cycler=das_cycler, show_zero_line=show_zero_line)
     plot_norm_sas(res, axes[1, 0], cycler=cycler, show_zero_line=show_zero_line)
-    plot_norm_das(res, axes[1, 1], cycler=cycler, show_zero_line=show_zero_line)
+    plot_norm_das(res, axes[1, 1], cycler=das_cycler, show_zero_line=show_zero_line)
 
 
 def plot_sas(

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -5,10 +5,13 @@ from typing import TYPE_CHECKING
 
 from glotaran.io.prepare_dataset import add_svd_to_dataset
 
+from pyglotaran_extras.deprecation import warn_deprecated
 from pyglotaran_extras.plotting.style import PlotStyle
 from pyglotaran_extras.plotting.utils import MinorSymLogLocator
 from pyglotaran_extras.plotting.utils import add_cycler_if_not_none
 from pyglotaran_extras.plotting.utils import shift_time_axis_by_irf_location
+from pyglotaran_extras.types import Unset
+from pyglotaran_extras.types import UnsetType
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -80,7 +83,7 @@ def plot_svd(
         show_legend=show_residual_svd_legend,
         irf_location=irf_location,
     )
-    plot_sv_residual(res, axes[0, 2], cycler=cycler)
+    plot_sv_residual(res, axes[0, 2])
     add_svd_to_dataset(dataset=res, name="data")
     plot_lsv_data(
         res,
@@ -100,7 +103,7 @@ def plot_svd(
         show_legend=show_data_svd_legend,
         irf_location=irf_location,
     )
-    plot_sv_data(res, axes[1, 2], cycler=cycler)
+    plot_sv_data(res, axes[1, 2])
 
 
 def plot_lsv_data(
@@ -181,7 +184,7 @@ def plot_sv_data(
     res: xr.Dataset,
     ax: Axis,
     indices: Sequence[int] = range(10),
-    cycler: Cycler | None = PlotStyle().cycler,
+    cycler: Cycler | None | UnsetType = Unset,
 ) -> None:
     """Plot singular values of the data matrix.
 
@@ -193,10 +196,15 @@ def plot_sv_data(
         Axis to plot on.
     indices : Sequence[int]
         Indices of the singular vector to plot. Defaults to range(10).
-    cycler : Cycler | None
-        Plot style cycler to use. Defaults to PlotStyle().cycler.
+    cycler : Cycler | None | UnsetType
+        Deprecated since it has no effect. Defaults to Unset.
     """
-    add_cycler_if_not_none(ax, cycler)
+    if cycler is not Unset:
+        warn_deprecated(
+            deprecated_qual_name_usage="'cycler' argument in 'plot_sv_data'",
+            new_qual_name_usage="matplotlib on the axis directly",
+            to_be_removed_in_version="0.9.0",
+        )
     dSV = res.data_singular_values  # noqa: N806
     dSV.sel(singular_value_index=indices[: len(dSV.singular_value_index)]).plot.line(
         "ro-", yscale="log", ax=ax
@@ -288,7 +296,7 @@ def plot_sv_residual(
     res: xr.Dataset,
     ax: Axis,
     indices: Sequence[int] = range(10),
-    cycler: Cycler | None = PlotStyle().cycler,
+    cycler: Cycler | None | UnsetType = Unset,
 ) -> None:
     """Plot singular values of the residual matrix.
 
@@ -300,10 +308,15 @@ def plot_sv_residual(
         Axis to plot on.
     indices : Sequence[int]
         Indices of the singular vector to plot. Defaults to range(10).
-    cycler : Cycler | None
-        Plot style cycler to use. Defaults to PlotStyle().cycler.
+    cycler : Cycler | None | UnsetType
+        Deprecated since it has no effect. Defaults to Unset.
     """
-    add_cycler_if_not_none(ax, cycler)
+    if cycler is not Unset:
+        warn_deprecated(
+            deprecated_qual_name_usage="'cycler' argument in 'plot_sv_residual'",
+            new_qual_name_usage="matplotlib on the axis directly",
+            to_be_removed_in_version="0.9.0",
+        )
     if "weighted_residual_singular_values" in res:
         rSV = res.weighted_residual_singular_values  # noqa: N806
     else:

--- a/pyglotaran_extras/types.py
+++ b/pyglotaran_extras/types.py
@@ -20,7 +20,10 @@ class UnsetType:
 
 
 Unset = UnsetType()
-"""Singleton to use when arguments are not provided where None is a valid value."""
+"""Value to use as default for an arguments where None is a meaningful value.
+
+This way we can prevent regressions.
+"""
 
 DatasetConvertible: TypeAlias = xr.Dataset | xr.DataArray | str | Path
 """Types of data which can be converted to a dataset."""

--- a/pyglotaran_extras/types.py
+++ b/pyglotaran_extras/types.py
@@ -10,6 +10,18 @@ from typing import TypeAlias
 import xarray as xr
 from glotaran.project.result import Result
 
+
+class UnsetType:
+    """Type for the ``Unset`` singleton."""
+
+    def __repr__(self) -> str:  # noqa: DOC
+        """Representation of instances in editors."""
+        return "Unset"
+
+
+Unset = UnsetType()
+"""Singleton to use when arguments are not provided where None is a valid value."""
+
 DatasetConvertible: TypeAlias = xr.Dataset | xr.DataArray | str | Path
 """Types of data which can be converted to a dataset."""
 ResultLike: TypeAlias = (


### PR DESCRIPTION
This change allows setting a different cycler for `DAS` and `SVD` plots.

I introduced an `Unset` singleton (similar to `pydantics` `Undefined`) in order to allow this change without regressing current behavior.

I also deprecated the `cycler` argument to `plot_sv_data` and `plot_sv_residual` since it doesn't have an effect since there is only a single scatter lines plot where the style is overwritten in the plot method call.

### Change summary

- [👌 Add das_cycler and svd_cycler to plot collection functions](https://github.com/glotaran/pyglotaran-extras/commit/e7756c4637fe01d6b96a9a3d67c0e00d4473e805)
- [🗑️ Deprecate cycler argument in plot_sv_data and plot_sv_residual](https://github.com/glotaran/pyglotaran-extras/commit/f1f3f657332bdd942b83974ee88a6d3597568ddf)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)