### PR TITLE
👌 Add use_svd_number switch to use SV number instead of index as label

### DIFF
--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -44,6 +44,7 @@ def plot_data_overview(
     vmin: float | None = None,
     vmax: float | None = None,
     svd_cycler: Cycler | None = PlotStyle().cycler,
+    use_svd_number: bool = False,
 ) -> tuple[Figure, Axes] | tuple[Figure, Axis]:
     """Plot data as filled contour plot and SVD components.
 
@@ -76,6 +77,9 @@ def plot_data_overview(
         Lower value to anchor the colormap. Defaults to None meaning it inferred from the data.
     svd_cycler : Cycler | None
         Plot style cycler to use for SVD plots. Defaults to ``PlotStyle().cycler``.
+    use_svd_number : bool
+        Whether to use singular value number (starts at 1) instead of singular value index
+        (starts at 0) for labeling in plot. Defaults to False.
 
     Returns
     -------
@@ -117,6 +121,7 @@ def plot_data_overview(
         linthresh=linthresh,
         irf_location=irf_location,
         cycler=svd_cycler,
+        use_svd_number=use_svd_number,
     )
     plot_sv_data(dataset, sv_ax)
     plot_rsv_data(
@@ -125,9 +130,14 @@ def plot_data_overview(
         indices=range(nr_of_data_svd_vectors),
         show_legend=False,
         cycler=svd_cycler,
+        use_svd_number=use_svd_number,
     )
     if show_data_svd_legend is True:
-        rsv_ax.legend(title="singular value index", loc="lower right", bbox_to_anchor=(1.13, 1))
+        rsv_ax.legend(
+            title="singular value number" if use_svd_number else "singular_value_index",
+            loc="lower right",
+            bbox_to_anchor=(1.13, 1),
+        )
     fig.suptitle(title, fontsize=16)
 
     if linlog:

--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -52,6 +52,7 @@ def plot_overview(
     show_zero_line: bool = True,
     das_cycler: Cycler | None | UnsetType = Unset,
     svd_cycler: Cycler | None | UnsetType = Unset,
+    use_svd_number: bool = False,
 ) -> tuple[Figure, Axes]:
     """Plot overview of the optimization result.
 
@@ -105,6 +106,9 @@ def plot_overview(
     svd_cycler : Cycler | None | UnsetType
         Plot style cycler to use for SVD plots. Defaults to ``Unset`` which means that the value
         of ``cycler`` is used.
+    use_svd_number : bool
+        Whether to use singular value number (starts at 1) instead of singular value index
+        (starts at 0) for labeling in plot. Defaults to False.
 
     Returns
     -------
@@ -154,6 +158,7 @@ def plot_overview(
         show_data_svd_legend=show_data_svd_legend,
         show_residual_svd_legend=show_residual_svd_legend,
         irf_location=irf_location,
+        use_svd_number=use_svd_number,
     )
     plot_residual(
         res,
@@ -179,6 +184,7 @@ def plot_simple_overview(
     show_irf_dispersion_center: bool = True,
     show_data: bool | None = False,
     svd_cycler: Cycler | None | UnsetType = Unset,
+    use_svd_number: bool = False,
 ) -> tuple[Figure, Axes]:
     """Plot simple overview.
 
@@ -203,6 +209,9 @@ def plot_simple_overview(
     svd_cycler : Cycler | None | UnsetType
         Plot style cycler to use for SVD plots. Defaults to ``Unset`` which means that the value
         of ``cycler`` is used.
+    use_svd_number : bool
+        Whether to use singular value number (starts at 1) instead of singular value index
+        (starts at 0) for labeling in plot. Defaults to False.
 
     Returns
     -------
@@ -223,8 +232,14 @@ def plot_simple_overview(
 
     irf_location = extract_irf_location(res, center_λ=res.coords["spectral"].to_numpy()[0])
 
-    plot_lsv_residual(res, ax=axes[1, 0], irf_location=irf_location, cycler=svd_cycler)
-    plot_rsv_residual(res, ax=axes[1, 1], cycler=svd_cycler)
+    plot_lsv_residual(
+        res,
+        ax=axes[1, 0],
+        irf_location=irf_location,
+        cycler=svd_cycler,
+        use_svd_number=use_svd_number,
+    )
+    plot_rsv_residual(res, ax=axes[1, 1], cycler=svd_cycler, use_svd_number=use_svd_number)
 
     plot_residual(
         res,


### PR DESCRIPTION
This change adds the switch `use_svd_number` to SVD related plot functions and plot collection functions that use them. The default is `False` not cause regressions.
When set to `True` it adds a new coordinate `singular value number` (`singular_value_index +1`) and changes the labels from `singular_value_index` to `singular value number` (legend or x axis label).
I intentionally choose `singular value number` instead of `singular_value_number` since:
- It looks nicer
- It is created on a copy of the data and not accessible in the data that are being plotted

Note that I also changed the legend title in `plot_data_overview` from `"singular value index"` to `"singular_value_index"` for the `use_svd_number=False` case to be consistent with "can I access it on the data?" reasoning.

### Change summary

- [👌 Add use_svd_number switch to use SV number instead of index as label](https://github.com/glotaran/pyglotaran-extras/commit/6e74a1c24b892e446aaabf25c660de318bace011)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)