### PR TITLE
🩹 Fix `use_svd_number` not being passed on to `plot_sv_data` in `plot_data_overview`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@
 - 👌 Use weighted residual instead of residual plots if present (#216)
 - 👌 Add color map arguments to plot_data_overview (#217)
 - 👌 Add das_cycler and svd_cycler to plot collection functions (#218)
+- 👌 Add use_svd_number switch to use SV number instead of index as label (#219)
+- 🩹 Fix use_svd_number not being passed on to plot_sv_data in plot_data_overview (#221)
 
 (changes-0_7_1)=
 

--- a/pyglotaran_extras/plotting/plot_data.py
+++ b/pyglotaran_extras/plotting/plot_data.py
@@ -123,7 +123,7 @@ def plot_data_overview(
         cycler=svd_cycler,
         use_svd_number=use_svd_number,
     )
-    plot_sv_data(dataset, sv_ax)
+    plot_sv_data(dataset, sv_ax, use_svd_number=use_svd_number)
     plot_rsv_data(
         dataset,
         rsv_ax,


### PR DESCRIPTION
This fixes an oversight in #219 where the `use_svd_number` argument wasn't passed long to `plot_sv_data` in `plot_data_overview` leading to inconsistent usage of svd number (starts at 1) and index (starts at 0)

### Change summary

- [🩹 Fix use_svd_number not being passed on to plot_sv_data in plot_data_overview](https://github.com/glotaran/pyglotaran-extras/commit/932e2717c2a86fc3af9c8a4f84dccfafbb5297fe)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)