### PR TITLE
📦 Use trusted publisher workflow for publishing to PyPI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,9 +152,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     needs: test
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyglotaran-extras
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -169,5 +173,4 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+          print-hash: true

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - 👌 Add das_cycler and svd_cycler to plot collection functions (#218)
 - 👌 Add use_svd_number switch to use SV number instead of index as label (#219)
 - 🩹 Fix use_svd_number not being passed on to plot_sv_data in plot_data_overview (#221)
+- 📦 Use trusted publisher workflow for publishing to PyPI (#222)
 
 (changes-0_7_1)=
 


### PR DESCRIPTION
Using [trusted publishing](https://docs.pypi.org/trusted-publishers/) is the new recommended way to publish packages on PyPI by PyPI and [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish/tree/v1.8.10/#trusted-publishing)

### Change summary

- [📦 Use trusted publisher workflow for publishing to pypi](https://github.com/glotaran/pyglotaran-extras/commit/c34d59839a221a80e2ce5ddaef91249f61da4444)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)