### PR TITLE
🩹 Fix very slow data/residual plots

### DIFF
--- a/pyglotaran_extras/plotting/plot_residual.py
+++ b/pyglotaran_extras/plotting/plot_residual.py
@@ -93,7 +93,7 @@ def plot_residual(
             res, ax=ax, spectral_axis="y", cycler=cycler, irf_location=irf_location
         )
         ax.set_xlabel("time")
-        ax.legend()
+        ax.legend(loc="upper right")
     if linlog:
         ax.set_xscale("symlog", linthresh=linthresh)
         ax.xaxis.set_minor_locator(MinorSymLogLocator(linthresh))


### PR DESCRIPTION
This reduces plot time of `plot_residual` (also used inside of `plot_overview`) from 3min to 3sec.
By default `matplotlib` tries to find the ideal position to place the legend where it least interferes with the plot itself, but since we add the line plot of the IRF on top of a 2D plot of the data or residual this wastes a lot of time without getting a conclusive result.

### Change summary

- [🩹 Hard code legend position in 2D plot so matplotlib does not try to find ideal position](https://github.com/glotaran/pyglotaran-extras/commit/8b6ccbf29812de0547dbc8ae895a64118195510b)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
