### PR TITLE
🚇🩹 Fix artifact collection

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -7,8 +7,14 @@ name: "Update pre-commit config"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-pre-commit:
+    permissions:
+      contents: write # for technote-space/create-pr-action to push code
+      pull-requests: write # for technote-space/create-pr-action to create a PR
     if: github.repository_owner == 'glotaran'
     name: Autoupdate pre-commit config
     runs-on: ubuntu-latest
@@ -20,13 +26,15 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: ~/.cache/pre-commit
+          path: |
+            ~/.cache/pre-commit
+            ~/.cache/pip
           key: pre-commit-autoupdate
 
       - name: Update pre-commit config packages
         uses: technote-space/create-pr-action@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.ACTION_TRIGGER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXECUTE_COMMANDS: |
             pip install pre-commit
             pre-commit autoupdate || (exit 0);

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,6 +59,8 @@ jobs:
   collect-artifacts:
     name: "Collect artifacts and reupload as bundel"
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [run-examples]
     steps:
       - name: Download All Artifacts

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,14 +70,15 @@ jobs:
           pattern: example-plots-*
           merge-multiple: true
 
-      - name: Delete Intermediate artifacts
-        uses: geekyeggo/delete-artifact@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: example-plots-*
-
       - name: Upload Example Plots Artifact
         uses: actions/upload-artifact@v4
         with:
           name: example-plots
           path: example-plots
+          overwrite: true
+
+      - name: Delete Intermediate artifacts
+        uses: geekyeggo/delete-artifact@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: example-plots-*


### PR DESCRIPTION
This fixes [CI tests failing](https://github.com/glotaran/pyglotaran-extras/actions/runs/7587303840/job/20703815446?pr=242) due to missing permissions for [`geekyeggo/delete-artifact@v4`](https://github.com/GeekyEggo/delete-artifact?tab=readme-ov-file#-usage)

### Change summary

- [🚇🩹 Fix GHA permissions](https://github.com/glotaran/pyglotaran-extras/commit/e1357c50d47afd1b0316dd0cffbe2726d1bcd91f)
- [🚇👌 Improve integration test artifact cleanup order](https://github.com/glotaran/pyglotaran-extras/commit/763f68887a33f5541d7cd25a030e9d421832289e)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
