### PR TITLE
🧪🩹 Fix deprecation test failing due to pandas deprecation warning

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,7 +1,9 @@
 ignore: []
 
-refactor:
-  skip: [simplify-boolean-comparison]
+rule_settings:
+  disable:
+    - simplify-boolean-comparison
+    - simplify-len-comparison
 
 metrics:
   quality_threshold: 25.0


### PR DESCRIPTION
This fixes that a test for a usage warning fails due to a `pandas` deprecation warning.
```
DeprecationWarning: 
  Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
  (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
  but was not found to be installed on your system.
  If this would cause problems for you,
  please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```

### Change summary

- [🧪🩹 Fix deprecation warning test by filtering warning category](https://github.com/glotaran/pyglotaran-extras/commit/fa50f43fa2761ee92c0a0d77467481f1701ec265)
- [🧰 Update sourcery config to new syntax](https://github.com/glotaran/pyglotaran-extras/commit/77e07d466b474e03368ece0971aa7369687fce84)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)