### PR TITLE
🚇🧹 Switch back to GeekyEggo/delete-artifact

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -76,8 +76,6 @@ jobs:
           overwrite: true
 
       - name: Delete Intermediate artifacts
-        #  TODO: Switc back to GeekyEggo/delete-artifact after
-        #  https://github.com/GeekyEggo/delete-artifact/pull/24 is merged
-        uses: s-weigand/delete-artifact@use-actions-artifact
+        uses: GeekyEggo/delete-artifact@v5
         with:
           name: example-plots-*


### PR DESCRIPTION
Switch back to `GeekyEggo/delete-artifact` after the permission issue fix was released.

### Change summary

- [🚇🧹 Switch back to GeekyEggo/delete-artifact](https://github.com/glotaran/pyglotaran-extras/commit/e8fd9533ecf2446edd817132d6f0b18fa0e30055)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)