### PR TITLE
🩹 Fix deprecation warning for using xr.Dataset.dim

### DIFF
--- a/pyglotaran_extras/plotting/plot_overview.py
+++ b/pyglotaran_extras/plotting/plot_overview.py
@@ -132,7 +132,7 @@ def plot_overview(
     irf_location = extract_irf_location(res, center_λ, main_irf_nr)
 
     if center_λ is None:  # center wavelength (λ in nm)
-        center_λ = min(res.dims["spectral"], round(res.dims["spectral"] / 2))
+        center_λ = min(res.sizes["spectral"], round(res.sizes["spectral"] / 2))
 
     # First and second row: concentrations - SAS/EAS - DAS
     plot_concentrations(

--- a/pyglotaran_extras/plotting/utils.py
+++ b/pyglotaran_extras/plotting/utils.py
@@ -147,7 +147,7 @@ def extract_irf_location(
     )
     if isinstance(irf_dispersion_center, xr.DataArray):
         if center_λ is None:  # center wavelength (λ in nm)
-            center_λ = min(res.dims["spectral"], round(res.dims["spectral"] / 2))
+            center_λ = min(res.sizes["spectral"], round(res.sizes["spectral"] / 2))
         return irf_dispersion_center.sel(spectral=center_λ, method="nearest").item()
 
     return irf_dispersion_center


### PR DESCRIPTION
This change fixes the deprecation warning:
```py
FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
  center_λ = min(res.dims["spectral"], round(res.dims["spectral"] / 2))
```
When `center_λ` has its default value of `None`.

However, when fixing this I found that we have a bug.
First of all:
```py
min(res.sizes["spectral"], round(res.sizes["spectral"] / 2))
```
will always return `round(res.sizes["spectral"] / 2)` since `res.sizes["spectral"]` is the length of the spectral coordinate (same goes for the current and past behavior of `res.dims["spectral"]`)

But since this value is later used with `xr.DataArray.sel` it leads to a wrong behavior since now `center_λ` isn't a spectral value but the index of it, resulting in the first wavelength being selected.

Example plot for the [4TT case study](https://github.com/glotaran/pyglotaran-release-paper-supplementary-information/tree/ff8cc59a5d055d746bed7b7fd68aaa2de5950e51/4TT)

## Current behavior with omitted `center_λ`
![image](https://github.com/glotaran/pyglotaran-extras/assets/9513634/0e3b642d-317e-43a1-bed7-9d5c4ffa5d03)

## Current behavior with set `center_λ`
![image](https://github.com/glotaran/pyglotaran-extras/assets/9513634/00e12f3a-b294-4fc3-9d0b-0046e28b5ec0)

So I think we should change the fallback to:
```py
center_λ = res.coords["spectral"].mean().item()
```
or

```py
center_λ = res.coords["spectral"].isel(spectral=res.sizes["spectral"]//2).item()
```
to take none equidistant spectral axes into account.

### Change summary

- [🩹 Fix deprecation warning for using xr.Dataset.dim](https://github.com/glotaran/pyglotaran-extras/commit/917c1253b7b57a9363e5f1782a0b98efb2620484)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)