### PR TITLE
🚇 Add CODECOV_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,8 @@ jobs:
         with:
           file: ./coverage.xml
           name: ${{ matrix.os }}-py${{ matrix.python-version }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-pyglotaran-dev:
     name: Test pyglotaran dev

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  require_ci_to_pass: no
+  require_ci_to_pass: false
 
 coverage:
   status:


### PR DESCRIPTION
The action [`codecov/codecov-action@v4` removed support for tokenless uploads](https://github.com/codecov/codecov-action/releases/tag/v4.0.0) so `pushes` to `main` failed upload coverage reports for the last 3 months.
However, [uploads from PRs done by forks still work](https://app.codecov.io/github/glotaran/pyglotaran-extras/pulls). so this [issue can only be seen for pushes on main](https://github.com/glotaran/pyglotaran-extras/actions/runs/9418439314)


### Change summary

- [🚇 Add CODECOV_TOKEN](https://github.com/glotaran/pyglotaran-extras/commit/be7234a9d90bac917038be517747757049604850)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
