### PR TITLE
📚 Prepare for v0.7.3 release

### DIFF
--- a/.github/requirements_min.txt
+++ b/.github/requirements_min.txt
@@ -5,7 +5,7 @@ numpy==1.22
 docstring-parser==0.16
 matplotlib==3.3
 pydantic==2.0.0
-pyglotaran==0.7.2
+pyglotaran==0.7.3
 ruamel-yaml==0.18.6
 tabulate==0.8.9
 xarray==2022.3

--- a/.github/requirements_min.txt
+++ b/.github/requirements_min.txt
@@ -5,7 +5,7 @@ numpy==1.22
 docstring-parser==0.16
 matplotlib==3.3
 pydantic==2.0.0
-pyglotaran==0.7.3
+pyglotaran==0.7.0
 ruamel-yaml==0.18.6
 tabulate==0.8.9
 xarray==2022.3

--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,14 @@
 
 (changes-0_7_3)=
 
-## 0.7.3 (Unreleased)
+## 0.7.3 (2024-08-25)
 
-- 🩹 Fix incompatibility of plot_data_and_fits with matplotlib>=3.8 (#275)
-- 🩹 Fix deprecation warning for using xr.Dataset.dim (#267)
+- ✨ Add configuration for plot functions (#288)
+- ✨ Add plot_pfid plot function (#283)
 - 🩹 Fix very slow data/residual plots (#239)
+- 🩹 Fix deprecation warning for using xr.Dataset.dim (#267)
+- 🩹🚇 Adapt to changed outputs in pyglotaran-examples GHA (#273)
+- 🩹 Fix incompatibility of plot_data_and_fits with matplotlib>=3.8 (#275)
 
 (changes-0_7_2)=
 

--- a/pyglotaran_extras/__init__.py
+++ b/pyglotaran_extras/__init__.py
@@ -70,7 +70,7 @@ __all__ = [
     "CONFIG",
 ]
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 SCRIPT_DIR = _find_script_dir_at_import(__file__)
 """User script dir determined during import."""


### PR DESCRIPTION
The v0.7.3 release will include support for plotting config and pfid_plot.

### Change summary

* 🚧 Bump version from 0.7.2 to 0.7.3.
* 📚 Updated changelog, added release date.
* ➡️ Set min pyglotaran version to v0.7.0.

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)

