### PR TITLE
🩹 Fix find_axes inside use_plot_config  causing TypeError with DataArray

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ## 0.7.4 (Unreleased)
 
+- 🩹 Fix find_axes inside use_plot_config causing TypeError with DataArray (#303)
+
 (changes-0_7_3)=
 
 ## 0.7.3 (2024-08-25)

--- a/pyglotaran_extras/config/plot_config.py
+++ b/pyglotaran_extras/config/plot_config.py
@@ -20,6 +20,7 @@ from typing import TypedDict
 from typing import cast
 
 import numpy as np
+import xarray as xr
 from docstring_parser import parse as parse_docstring
 from matplotlib.axes import Axes
 from pydantic import BaseModel
@@ -479,7 +480,9 @@ def find_axes(
     Axes
     """
     for value in values:
-        if isinstance(value, str):
+        # This are iterables where we are sure that they can not contain `Axes` so we can skip them
+        # early
+        if isinstance(value, str | xr.Dataset | xr.DataArray):
             continue
         elif isinstance(value, Axes):
             yield value

--- a/pyglotaran_extras/config/plot_config.py
+++ b/pyglotaran_extras/config/plot_config.py
@@ -488,6 +488,8 @@ def find_axes(
             yield value
         elif isinstance(value, np.ndarray):
             yield from find_axes(value.flatten())
+        elif isinstance(value, Mapping):
+            yield from find_axes(value.values())
         elif isinstance(value, Iterable):
             yield from find_axes(value)
 

--- a/tests/config/test_plot_config.py
+++ b/tests/config/test_plot_config.py
@@ -475,10 +475,10 @@ def test_find_axes():
     assert generator_is_exhausted(find_axes(base_values)) is True
 
     _, ax = plt.subplots()
-    single_ax_gen = find_axes([*base_values, ax])
+    dict_ax_gen = find_axes([*base_values, ax])
 
-    assert next(single_ax_gen) is ax
-    assert generator_is_exhausted(single_ax_gen) is True
+    assert next(dict_ax_gen) is ax
+    assert generator_is_exhausted(dict_ax_gen) is True
 
     _, np_axes = plt.subplots(1, 2)
 
@@ -503,6 +503,11 @@ def test_find_axes():
     assert next(multiple_axes_gen) is ax
     assert next(multiple_axes_gen) is ax1
     assert generator_is_exhausted(multiple_axes_gen) is True
+
+    dict_ax_gen = find_axes([*base_values, {"ax": ax}])
+
+    assert next(dict_ax_gen) is ax
+    assert generator_is_exhausted(dict_ax_gen) is True
 
 
 def test_use_plot_config(mock_config: tuple[Config, dict[str, Any]]):

--- a/tests/config/test_plot_config.py
+++ b/tests/config/test_plot_config.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import pytest
+import xarray as xr
 from jsonschema import ValidationError as SchemaValidationError
 from jsonschema import validate
 from pydantic import ValidationError as PydanticValidationError
@@ -466,7 +467,10 @@ def test_find_not_user_provided_kwargs():
 def test_find_axes():
     """Get axes value from iterable of values."""
 
-    base_values = ["foo", True, 1.5]
+    data_array = xr.DataArray([[0, 1]], coords={"time": [0], "spectral": [500, 510]})
+    data_set = xr.Dataset({"data": data_array})
+
+    base_values = ["foo", True, 1.5, data_array, data_set]
 
     assert generator_is_exhausted(find_axes(base_values)) is True
 


### PR DESCRIPTION
This PR fixes that `find_axes` raises a `TypeError` when a config enabled function (has a `use_plot_config` decorator) has a `xr.DataArray` argument or return value.

Thanks @jsnel for discovering this error.

We didn't catch this error earlier since all our examples use `xr.Dataset` and when iterating over `xr.Dataset` you get the keys of the `data_vars`.
For `xr.DataArray` however `find_axes` recursively looks up sub `xr.DataArray` until it gets to a point where the value is a single item `xr.DataArray` and raises the `TypeError` due to the dimensionality check in its `__iter__`.

In addition to fixing the above described bug, this PR also fixes that `Mappings` of `Axes` as arguments or return values wouldn't have been handled correctly.

**Minimal reproducible example:**
```py
import xarray as xr
from pyglotaran_extras import plot_data_overview

plot_data_overview(xr.DataArray([[0, 1]], coords={"time": [0], "spectral": [500, 510]}))
```
**Error before fix:**
```py
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[10], line 4
      1 import xarray as xr
      2 from pyglotaran_extras import plot_data_overview
----> 4 plot_data_overview(xr.DataArray([[0, 1]], coords={"time": [0], "spectral": [500, 510]}))

File ~/git/GTA/pyglotaran-extras/pyglotaran_extras/config/plot_config.py:525, in use_plot_config.<locals>.outer_wrapper.<locals>.wrapper(*args, **kwargs)
    523 arg_axes = find_axes(getcallargs(func, *args, **updated_kwargs).values())
    524 return_values = func(*args, **updated_kwargs)
--> 525 function_config.update_axes_labels(arg_axes)
    527 if isinstance(return_values, Iterable):
    528     return_axes = find_axes(return_values)

File ~/git/GTA/pyglotaran-extras/pyglotaran_extras/config/plot_config.py:268, in PerFunctionPlotConfig.update_axes_labels(self, axes)
    266     self.update_axes_labels((axes,))
    267     return
--> 268 for ax in axes:
    269     if isinstance(ax, Axes):
    270         orig_x_label = ax.get_xlabel()

File ~/git/GTA/pyglotaran-extras/pyglotaran_extras/config/plot_config.py:489, in find_axes(values)
    487     yield from find_axes(value.flatten())
    488 elif isinstance(value, Iterable):
--> 489     yield from find_axes(value)

File ~/git/GTA/pyglotaran-extras/pyglotaran_extras/config/plot_config.py:489, in find_axes(values)
    487     yield from find_axes(value.flatten())
    488 elif isinstance(value, Iterable):
--> 489     yield from find_axes(value)

File ~/git/GTA/pyglotaran-extras/pyglotaran_extras/config/plot_config.py:489, in find_axes(values)
    487     yield from find_axes(value.flatten())
    488 elif isinstance(value, Iterable):
--> 489     yield from find_axes(value)

File ~/git/GTA/pyglotaran-extras/pyglotaran_extras/config/plot_config.py:481, in find_axes(values)
    467 def find_axes(
    468     values: Iterable[Any],
    469 ) -> Generator[Axes, None, None]:
    470     """Iterate over values and yield the values that are ``Axes``.
    471 
    472     Parameters
   (...)
    479     Axes
    480     """
--> 481     for value in values:
    482         if isinstance(value, str):
    483             continue

File ~/git/GTA/pyglotaran-extras/.venv/lib/python3.10/site-packages/xarray/core/common.py:213, in AbstractArray.__iter__(self)
    211 def __iter__(self: Any) -> Iterator[Any]:
    212     if self.ndim == 0:
--> 213         raise TypeError("iteration over a 0-d array")
    214     return self._iter()

TypeError: iteration over a 0-d array
```

### Change summary

- [🧪 Added test reproducing error in find_axes when a xr.DataArray is passed](https://github.com/glotaran/pyglotaran-extras/commit/69780cf196a0a2003d1a535f7bd3029a8c638b0b) 
- [🩹 Fix issue with xr.DataArray](https://github.com/glotaran/pyglotaran-extras/commit/f9598899faf0828b6b8e5cd6a86ad0a9760d83ed)
- [👌 Endure Mapping of Axes is handled correctly by find_axes](https://github.com/glotaran/pyglotaran-extras/commit/3e5def915592a2cf02e0877a4ade67cda88f0567)



### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

