### PR TITLE
📚🩹 Use fixed pydata-sphinx-theme from fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
   docs:
     name: Build Docs
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -48,6 +51,9 @@ jobs:
   docs-link:
     name: Check Doc Links
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,22 +33,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
+      - name: Setup docs env same as on RTD
+        uses: mamba-org/setup-micromamba@v1
         with:
-          conda-channels: conda-forge
-          activate-conda: false
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Install dependencies
-        run: |
-          conda install -y pandoc
-          python -m pip install -U pip wheel
-          python -m pip install ".[docs]"
+          environment-file: docs/environment.yml
+          cache-environment: true
 
       - name: Show installed dependencies
         run: pip freeze
@@ -63,22 +52,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1
+      - name: Setup docs env same as on RTD
+        uses: mamba-org/setup-micromamba@v1
         with:
-          conda-channels: conda-forge
-          activate-conda: false
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Install dependencies
-        run: |
-          conda install -y pandoc
-          python -m pip install -U pip wheel
-          python -m pip install ".[docs]"
+          environment-file: docs/environment.yml
+          cache-environment: true
 
       - name: Show installed dependencies
         run: pip freeze

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,10 +24,6 @@ HERE = Path(__file__).parent
 
 pyglotaran_extras.create_config_schema(HERE/"_static")
 
-# Workaround for error caused by pydata-sphinx-theme==0.16.1 during link check
-# TODO: Remove workaround when fix is available
-(HERE / "_build/linkcheck/_static").mkdir(parents=True, exist_ok=True)
-
 # -- General configuration ---------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/requirements_pinned.txt
+++ b/requirements_pinned.txt
@@ -10,3 +10,5 @@ pyglotaran==0.7.3
 ruamel-yaml==0.18.10
 tabulate==0.9.0
 xarray==2025.1.1
+# Fixes for pydata-sphinx-theme until a new upstream release is available
+git+https://github.com/s-weigand/pydata-sphinx-theme.git@fixes


### PR DESCRIPTION
Today I found that our docs are broken due to a bug when building PDFs.

This PR changes the [pydata-sphinx-theme](https://github.com/pydata/pydata-sphinx-theme) from the published upstream project to a branch on my for including the following fixes:

- https://github.com/pydata/pydata-sphinx-theme/pull/2097
- https://github.com/pydata/pydata-sphinx-theme/pull/2076

I also went ahead and removed the workaround on our side since it isn't needed with the fix on my fork in place.

### Change summary

- [📚🩹 Use fixed pydata-sphinx-theme from fork](https://github.com/glotaran/pyglotaran-extras/commit/5f3bedfba3a9e765d857a9313e9f14cc25d7ba60)
- [🚇🩹 Setup docs env same as on RTD](https://github.com/glotaran/pyglotaran-extras/pull/334/commits/365899d39886ef2e8ae0dfdf94521e07ecf63a26)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)

## Summary by Sourcery

Bug Fixes:
- Fixes a bug in pydata-sphinx-theme that was breaking the documentation build.