### PR TITLE
🩹 Ensure residual SVD in always available in SVD plot functions

### DIFF
--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
 
-def ensure_residual_svd(res:xr.Dataset)->None:
+def ensure_residual_svd(res: xr.Dataset) -> None:
     """Add SVD of residual and weighted residual to dataset.
 
     Parameters
@@ -35,6 +35,7 @@ def ensure_residual_svd(res:xr.Dataset)->None:
     if "weighted_residual" in res:
         add_svd_to_dataset(dataset=res, name="weighted_residual")
     add_svd_to_dataset(dataset=res, name="residual")
+
 
 @use_plot_config(exclude_from_config=("cycler",))
 def plot_svd(

--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -24,6 +24,18 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
 
+def ensure_residual_svd(res:xr.Dataset)->None:
+    """Add SVD of residual and weighted residual to dataset.
+
+    Parameters
+    ----------
+    res : xr.Dataset
+        Result dataset
+    """
+    if "weighted_residual" in res:
+        add_svd_to_dataset(dataset=res, name="weighted_residual")
+    add_svd_to_dataset(dataset=res, name="residual")
+
 @use_plot_config(exclude_from_config=("cycler",))
 def plot_svd(
     res: xr.Dataset,
@@ -68,10 +80,7 @@ def plot_svd(
         Whether to use singular value number (starts at 1) instead of singular value index
         (starts at 0) for labeling in plot. Defaults to False.
     """
-    if "weighted_residual" in res:
-        add_svd_to_dataset(dataset=res, name="weighted_residual")
-    else:
-        add_svd_to_dataset(dataset=res, name="residual")
+    ensure_residual_svd(res)
     plot_lsv_residual(
         res,
         axes[0, 0],
@@ -299,6 +308,7 @@ def plot_lsv_residual(
         (starts at 0) for labeling in plot. Defaults to False.
     """
     add_cycler_if_not_none(ax, cycler)
+    ensure_residual_svd(res)
     rLSV: xr.DataArray = (  # noqa: N806
         res.weighted_residual_left_singular_vectors
         if "weighted_residual_left_singular_vectors" in res
@@ -352,6 +362,7 @@ def plot_rsv_residual(
         (starts at 0) for labeling in plot. Defaults to False.
     """
     add_cycler_if_not_none(ax, cycler)
+    ensure_residual_svd(res)
     rRSV: xr.DataArray = (  # noqa: N806
         res.weighted_residual_right_singular_vectors
         if "weighted_residual_right_singular_vectors" in res
@@ -399,6 +410,7 @@ def plot_sv_residual(
             new_qual_name_usage="matplotlib on the axis directly",
             to_be_removed_in_version="0.9.0",
         )
+    ensure_residual_svd(res)
     rSV: xr.DataArray = (  # noqa: N806
         res.weighted_residual_singular_values
         if "weighted_residual_singular_values" in res


### PR DESCRIPTION
This change ensure that if a dataset has a residual the SVD of the residual is also available for plotting.
This was already done in `plot_svd`, however if any of the sub functions was used (e.g. in `plot_overview`) the existence of the SVD was not ensured and the plot function did crash.

**Note:**
The [`add_svd_to_dataset`](https://github.com/glotaran/pyglotaran/blob/204c30790afc28f6726aa595c211bc4a9c6b5129/glotaran/io/prepare_dataset.py#L60) is basically a noop when the SVD is already present.

### Change summary

- [🩹 Ensure residual SVD in always available in SVD plot functions](https://github.com/glotaran/pyglotaran-extras/commit/9900a3d80baf4ab65e4b923fbf290a25e7cabb01)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)

## Summary by Sourcery

Ensure residual SVD data is always available before generating SVD-based residual plots to prevent crashes.

Bug Fixes:
- Prevent SVD residual plotting functions from crashing when the residual SVD has not yet been computed by ensuring it is added to the dataset on demand.

Enhancements:
- Introduce a shared helper to populate residual and weighted residual SVD information and reuse it across SVD plotting functions to centralize this logic.