### PR TITLE
👌Reduce unnecessary computation and reduce RAM usage in SVD calculation

### DIFF
--- a/pyglotaran_extras/plotting/plot_svd.py
+++ b/pyglotaran_extras/plotting/plot_svd.py
@@ -34,7 +34,8 @@ def ensure_residual_svd(res: xr.Dataset) -> None:
     """
     if "weighted_residual" in res:
         add_svd_to_dataset(dataset=res, name="weighted_residual")
-    add_svd_to_dataset(dataset=res, name="residual")
+    else:
+        add_svd_to_dataset(dataset=res, name="residual")
 
 
 @use_plot_config(exclude_from_config=("cycler",))


### PR DESCRIPTION
As the copilot correctly pointed out, this changed in last PR (#381 ), and on second thought there's no reason to keep thing in memory that we don't intend to use. RAM's expensive enough these days

## Summary by Sourcery

Enhancements:
- Skip residual SVD computation when a weighted residual SVD is already added to the dataset to reduce unnecessary work and RAM usage.