### PR TITLE
👌 Add `scale_factors` argument to `plot_sas` and 2 additional data color pairs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         args: [--in-place, --config, ./pyproject.toml]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.11.1"
+    rev: "v2.16.0"
     hooks:
       - id: pyproject-fmt
 
@@ -39,14 +39,14 @@ repos:
 
   # Notebook tools
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.9.0
+    rev: 186d22f
     hooks:
       - id: nbstripout
         args: [--drop-empty-cells]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.14
+    rev: v0.15.1
     hooks:
       - id: ruff
         name: "ruff sort imports notebooks"
@@ -88,7 +88,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.14
+    rev: v0.15.1
     hooks:
       - id: ruff
         name: "ruff sort imports"

--- a/docs/_static/css/mermaid_dark.css
+++ b/docs/_static/css/mermaid_dark.css
@@ -1,4 +1,4 @@
-/* Overwrite edge colors and arror marker color in dakr mode. in */
+/* Overwrite edge colors and arrow marker color in dark mode. */
 html[data-theme="dark"] pre.mermaid {
   & .marker {
     fill: #e3e3e3 !important;

--- a/docs/_static/css/xarray_dark.css
+++ b/docs/_static/css/xarray_dark.css
@@ -1,0 +1,14 @@
+/* Overwrite xarray wrapper in dark mode. */
+html[data-theme="dark"] div.cell_output div.output.text_html {
+  background-color: var(--pst-color-on-background) !important;
+  color: var(--pst-color-text-base) !important;
+}
+
+/* Tables */
+html[data-theme="dark"] div.cell_output table {
+  color: var(--pst-color-text-base) !important;
+}
+
+html[data-theme="dark"] div.cell_output tbody tr:nth-child(odd) {
+  background-color: var(--pst-color-on-background) !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ html_sidebars = {
     'contributing': [],
     'changelog': [],
     'config/project/subproject/config_docs': [],
+    'notebooks/tips_and_tricks': [],
 }
 
 # Theme options are theme-specific and customize the look and feel of a
@@ -147,6 +148,7 @@ html_sidebars = {
 html_static_path = ["_static"]
 html_css_files = [
     'css/mermaid_dark.css',
+    'css/xarray_dark.css',
 ]
 
 # -- Options for HTMLHelp output ---------------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 installation
 usage
 config/project/subproject/config_docs
+notebooks/tips_and_tricks
 api_docs
 contributing
 changelog

--- a/docs/notebooks/tips_and_tricks.ipynb
+++ b/docs/notebooks/tips_and_tricks.ipynb
@@ -68,7 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the fist look we can see that the `Result` only contains a single dataset named `dataset_1`.\n",
+    "From the first look we can see that the `Result` only contains a single dataset named `dataset_1`.\n",
     "\n",
     "For ease of use let's assign it to a variable `ds` and have a closer look."
    ]
@@ -118,7 +118,7 @@
     "\n",
     "Now that we know how to access the data we are interested in, let's plot them.\n",
     "\n",
-    "Lucky for use `xarray` comes with built in convenience functionality that lets us quickly have a look at the data. \n",
+    "Lucky for us `xarray` comes with built in convenience functionality that lets us quickly have a look at the data. \n",
     "\n",
     "For data with up to two dimension `xarray` is pretty good guessing what we want to plot by simply \n",
     "calling the `plot` attribute on our data."
@@ -190,7 +190,7 @@
    "metadata": {},
    "source": [
     "Even so we now have a line plot this isn't what we wanted because each point on the `spectral` \n",
-    "dimension resulted in it's own line, leaving us with a plot that contains 72 lines."
+    "dimension resulted in its own line, leaving us with a plot that contains 72 lines."
    ]
   },
   {
@@ -289,9 +289,9 @@
    "source": [
     "from pyglotaran_extras.plotting.utils import extract_irf_location\n",
     "\n",
-    "if_location = extract_irf_location(ds)\n",
+    "irf_location = extract_irf_location(ds)\n",
     "ds_shifted = ds.copy()\n",
-    "ds_shifted[\"time\"] = ds.time - if_location\n",
+    "ds_shifted[\"time\"] = ds.time - irf_location\n",
     "ds_shifted.isel(time=slice(80, 200)).irf.plot();"
    ]
   },

--- a/docs/notebooks/tips_and_tricks.ipynb
+++ b/docs/notebooks/tips_and_tricks.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "Lucky for us `xarray` comes with built in convenience functionality that lets us quickly have a look at the data. \n",
     "\n",
-    "For data with up to two dimension `xarray` is pretty good guessing what we want to plot by simply \n",
+    "For data with up to two dimensions `xarray` is pretty good guessing what we want to plot by simply \n",
     "calling the `plot` attribute on our data."
    ]
   },
@@ -189,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Even so we now have a line plot this isn't what we wanted because each point on the `spectral` \n",
+    "Even though we now have a line plot this isn't what we wanted because each point on the `spectral` \n",
     "dimension resulted in its own line, leaving us with a plot that contains 72 lines."
    ]
   },
@@ -574,7 +574,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.2"
+   "version": "3.10.19"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/tips_and_tricks.ipynb
+++ b/docs/notebooks/tips_and_tricks.ipynb
@@ -1,0 +1,575 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Going beyond builtin\n",
+    "\n",
+    "The `pyglotaran-extras` are a utility library enabling users to quickly inspect and visualize \n",
+    "results from `pyglotaran` in the most common ways we know of.\n",
+    "\n",
+    "However since specific needs can vary a lot on a case by case basis and we can't possibly \n",
+    "anticipate all user needs. \n",
+    "\n",
+    "Thus it is important that you as a user are familiar with the usage of the underlying libraries \n",
+    "that the `pyglotaran-extras` package uses to facilitate its functionality and be able to help yourself.\n",
+    "\n",
+    "> Giving a user a plot will fit their needs for this case, teaching a user how to create their own \n",
+    "> plots will help them with all their needs.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basics of working with `xarray`\n",
+    "\n",
+    "The `xarray` library is the backbone of how `pyglotaran` stores result data, which is why it is \n",
+    "important to know how to work with it.\n",
+    "\n",
+    "Let's start by creating an example `Result` by utilizing the simulation capabilities of `pyglotaran`\n",
+    "and the included example test data.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from glotaran.testing.simulated_data.parallel_spectral_decay import SCHEME\n",
+    "from glotaran.optimization.optimize import optimize\n",
+    "\n",
+    "result = optimize(SCHEME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inspecting result data\n",
+    "\n",
+    "Before we can select data we first need to know which data we actually have.\n",
+    "\n",
+    "So let's have a look at the `data` attribute of our example `Result`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From the fist look we can see that the `Result` only contains a single dataset named `dataset_1`.\n",
+    "\n",
+    "For ease of use let's assign it to a variable `ds` and have a closer look."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = result.data[\"dataset_1\"]\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accessing data inside of a dataset\n",
+    "\n",
+    "When looking at the `Data Variables` we can see that we have variable called `fitted_data` which are 2D data\n",
+    "with the dimensions `time` and `spectral`.\n",
+    "\n",
+    "We can access this data variable in 3 ways:\n",
+    "- Attribute style accessing with `ds.fitted_data`\n",
+    "- Dict like accessing with `ds[\"fitted_data\"]`\n",
+    "- Via `data_vars` using `ds.data_vars[\"fitted_data\"]`\n",
+    "\n",
+    "Those three ways to access `fitted_data` are equivalent and give you the same data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'{ds.fitted_data.equals(ds[\"fitted_data\"])=}')\n",
+    "print(f'{ds.fitted_data.equals(ds.data_vars[\"fitted_data\"])=}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Basic plotting\n",
+    "\n",
+    "Now that we know how to access the data we are interested in, let's plot them.\n",
+    "\n",
+    "Lucky for use `xarray` comes with built in convenience functionality that lets us quickly have a look at the data. \n",
+    "\n",
+    "For data with up to two dimension `xarray` is pretty good guessing what we want to plot by simply \n",
+    "calling the `plot` attribute on our data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.fitted_data.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> [!Note]\n",
+    "> We added the `;` at the end so the underlying structure of the python object which `.plot()` returns won't distract us."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we rather want `time` to be on the x-axis we can simply tell `xarray` so. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.fitted_data.plot(x=\"time\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While a 2D plot is pretty to look at, it often doesn't provide us with enough detail and we would \n",
+    "rather see multiple lines plotted.\n",
+    "\n",
+    "This can easily be achieved by telling `xarray` which kind of plot we want rather than letting it \n",
+    "guess based on the dimensionality of our data.\n",
+    "\n",
+    "Since we want to plot lines we will use `.line` method on the `plot` attribute.\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> Since we have 2D data it is now required to tell `xarray` over which dimension we want to plot\n",
+    "> so it can create a separate line of each data point along the other dimension. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.fitted_data.plot.line(x=\"time\", add_legend=False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Even so we now have a line plot this isn't what we wanted because each point on the `spectral` \n",
+    "dimension resulted in it's own line, leaving us with a plot that contains 72 lines."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data selection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To reduce the number of lines we need to select a subset of our data based on the values of a dimension.\n",
+    "\n",
+    "The `xarray` library provides two main ways to select data:\n",
+    "- **`.sel()`** - Select by dimension label values (e.g., select a specific wavelength)\n",
+    "- **`.isel()`** - Select by dimension index (e.g., select the 5th time point)\n",
+    "\n",
+    "Let's start with selecting a single wavelength from our fitted data using `.sel()`.\n",
+    "\n",
+    "Since we have discrete wavelength values, we need to use the `method=\"nearest\"` parameter to find \n",
+    "the closest match to our desired value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.fitted_data.sel(spectral=0, method=\"nearest\").plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Much better! Now we have a single trace showing how the fitted data changes over time at a specific \n",
+    "wavelength.\n",
+    "\n",
+    "We can also select multiple values at once by passing a list. This is particularly useful when \n",
+    "working with categorical dimensions like `species`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.sel(species=[\"species_1\", \"species_2\"]).species_associated_spectra.plot.line(\n",
+    "    x=\"spectral\"\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can clearly see the individual species associated spectra for the selected species.\n",
+    "\n",
+    "When you want to select data by position rather than by label, use `.isel()` (index select).\n",
+    "\n",
+    "This is especially useful when working with slices to select ranges of data. For example, let's \n",
+    "plot a subset of our IRF data from time index 80 to 200."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.isel(time=slice(80, 200)).irf.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Modifying coordinates\n",
+    "\n",
+    "Sometimes you need to transform the coordinate values themselves rather than just selecting subsets \n",
+    "of data. \n",
+    "\n",
+    "A common use case is shifting the time axis so that time zero corresponds to the IRF location.\n",
+    "\n",
+    "The `pyglotaran-extras` package provides helper functions like `extract_irf_location()` to make \n",
+    "this easier. Let's extract the IRF location and shift the time coordinates accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyglotaran_extras.plotting.utils import extract_irf_location\n",
+    "if_location = extract_irf_location(ds)\n",
+    "ds_shifted = ds.copy()\n",
+    "ds_shifted[\"time\"] = ds.time - if_location\n",
+    "ds_shifted.isel(time=slice(80, 200)).irf.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By combining `.sel()`, `.isel()` and the various plotting methods, you can create customized \n",
+    "visualizations that exactly fit your analysis needs.\n",
+    "\n",
+    "> [!TIP]\n",
+    "> You can chain selections together: `ds.sel(species=\"species_1\").isel(time=slice(0, 100))` \n",
+    "> to first select by label and then by index."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with cyclers\n",
+    "\n",
+    "One of the most common plot customizations besides data selection is changing the plot style.\n",
+    "\n",
+    "> [!NOTE]\n",
+    "> For more information on how to use `cycler` have a look at the [`matplotlib` documentation](https://matplotlib.org/cycler/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cycler import cycler\n",
+    "from pyglotaran_extras.plotting.style import PlotStyle\n",
+    "from pyglotaran_extras.inspect import inspect_cycler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inspecting the default cycler\n",
+    "\n",
+    "The `pyglotaran-extras` package comes with a built-in `PlotStyle` that defines a default `cycler` used by all plotting functions.\n",
+    "\n",
+    "The `inspect_cycler` function lets us visualize the properties of a cycler as a table, including a small preview of each line style. Let's have a look at the default one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspect_cycler(PlotStyle().cycler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's quite a lot of entries! Let's check exactly how many styles are defined in the default cycler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(PlotStyle().cycler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Slicing a cycler\n",
+    "\n",
+    "For many plots we only need a handful of styles. Just like a Python list, a `Cycler` can be sliced\n",
+    "to create a smaller subset. Let's create a `small_cycler` containing only the first 3 entries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "small_cycler = PlotStyle().cycler[:3]\n",
+    "inspect_cycler(small_cycler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Repeating a cycler\n",
+    "\n",
+    "If you need the same set of styles to repeat, you can multiply a cycler by an integer.\n",
+    "This simply concatenates the cycler with itself the given number of times."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspect_cycler(small_cycler * 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding properties with `+`\n",
+    "\n",
+    "The `+` operator performs an **element-wise** combination of two cyclers of equal length.\n",
+    "This is useful when you want to add a new property (e.g. `linestyle`) to an existing cycler.\n",
+    "\n",
+    "Since element-wise addition requires both cyclers to have the same length, we multiply the\n",
+    "single-entry linestyle cycler by `len(small_cycler)` to match sizes first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspect_cycler(small_cycler + cycler(linestyle=[\":\"]) * len(small_cycler))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Combining cyclers with `*` (outer product)\n",
+    "\n",
+    "The `*` operator between two cyclers creates an **outer product**, generating all possible\n",
+    "combinations of both cyclers' entries.\n",
+    "\n",
+    "When one of the cyclers has a single entry, the result simply applies that property to every entry\n",
+    "of the other cycler — similar to using `+`, but without needing to match lengths manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspect_cycler(small_cycler *cycler(linestyle=[\":\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the second cycler has **multiple entries**, the outer product creates all combinations — \n",
+    "resulting in `len(a) × len(b)` total entries. Here our 3-entry color cycler combined with a\n",
+    "2-entry linestyle cycler gives us 6 distinct styles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspect_cycler(small_cycler*cycler(linestyle=[\"-\",\":\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> [!IMPORTANT]\n",
+    "> Same as in math the **outer product** isn't commutative, so the order matters!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspect_cycler(cycler(linestyle=[\"-\",\":\"]) * small_cycler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compose your own plotting function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we know how to work with `xarray` data and customize plot styles with cyclers, let's put it all together.\n",
+    "\n",
+    "The `pyglotaran-extras` package is designed to be **composable**, \n",
+    "its individual plot functions like `plot_concentrations`, `plot_sas`, `plot_svd`, `plot_residual`, etc. \n",
+    "are all building blocks that can be freely reused and rearranged to create exactly the visualization you need.\n",
+    "\n",
+    "Instead of being limited to the built-in overview plots, you can:\n",
+    "- Pick only the specific plot functions relevant to your analysis\n",
+    "- Arrange them in any layout using `matplotlib`'s subplot system\n",
+    "- Pass in a custom `cycler` to keep a consistent style across all panels\n",
+    "- Apply additional `matplotlib` customizations on top\n",
+    "\n",
+    "Let's create a custom plotting function that combines concentration and spectra plots side by side, \n",
+    "using a custom cycler we build from what we learned above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cycler import cycler\n",
+    "from pyglotaran_extras import plot_concentrations\n",
+    "from pyglotaran_extras import plot_sas, add_subplot_labels\n",
+    "from pyglotaran_extras.plotting.style import PlotStyle\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "custom_cycler = PlotStyle().cycler[:3] + cycler(linestyle=[\"-\",\":\", \"--\"])\n",
+    "\n",
+    "def plot_concentration_and_spectra(result_dataset):\n",
+    "    fig, axes = plt.subplots(1, 2, figsize=(15, 4))\n",
+    "    plot_concentrations(result_dataset, axes[0], center_λ=0, linlog=True, cycler=custom_cycler)\n",
+    "    plot_sas(result_dataset, axes[1], cycler=custom_cycler)\n",
+    "    return fig, axes\n",
+    "\n",
+    "\n",
+    "fig, axes = plot_concentration_and_spectra(ds.isel(time=slice(100,None)))\n",
+    "axes[0].set_xlabel(\"Time (ps)\")\n",
+    "axes[0].set_ylabel(\"\")\n",
+    "axes[0].axhline(0, color=\"k\", linewidth=0.5)\n",
+    "axes[1].set_xlabel(\"Wavelength (nm)\")\n",
+    "axes[1].set_ylabel(\"SADS (OD)\")\n",
+    "axes[1].set_title(\"SADS\")\n",
+    "axes[1].axhline(0, color=\"k\", linewidth=0.5)\n",
+    "add_subplot_labels(axes, label_format_function=\"lower_case_letter\", label_format_template=\"{})\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> [!TIP]\n",
+    "> To reduce repetition check out the [documentation on using plot config](../config/project/subproject/config_docs.ipynb) and how to use it for your own plot functions ([`use_plot_config`](../../api/pyglotaran_extras/pyglotaran_extras.config.plot_config.html#pyglotaran_extras.config.plot_config.use_plot_config))."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/notebooks/tips_and_tricks.ipynb
+++ b/docs/notebooks/tips_and_tricks.ipynb
@@ -137,8 +137,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> [!Note]\n",
-    "> We added the `;` at the end so the underlying structure of the python object which `.plot()` returns won't distract us."
+    "```{note}\n",
+    "We added the `;` at the end so the underlying structure of the python object which `.plot()` returns won't distract us.\n",
+    "```"
    ]
   },
   {
@@ -169,9 +170,10 @@
     "\n",
     "Since we want to plot lines we will use `.line` method on the `plot` attribute.\n",
     "\n",
-    "> [!NOTE]\n",
-    "> Since we have 2D data it is now required to tell `xarray` over which dimension we want to plot\n",
-    "> so it can create a separate line of each data point along the other dimension. "
+    "```{note}\n",
+    "Since we have 2D data it is now required to tell `xarray` over which dimension we want to plot\n",
+    "so it can create a separate line of each data point along the other dimension. \n",
+    "```"
    ]
   },
   {
@@ -240,9 +242,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds.sel(species=[\"species_1\", \"species_2\"]).species_associated_spectra.plot.line(\n",
-    "    x=\"spectral\"\n",
-    ");"
+    "ds.sel(species=[\"species_1\", \"species_2\"]).species_associated_spectra.plot.line(x=\"spectral\");"
    ]
   },
   {
@@ -288,6 +288,7 @@
    "outputs": [],
    "source": [
     "from pyglotaran_extras.plotting.utils import extract_irf_location\n",
+    "\n",
     "if_location = extract_irf_location(ds)\n",
     "ds_shifted = ds.copy()\n",
     "ds_shifted[\"time\"] = ds.time - if_location\n",
@@ -301,9 +302,10 @@
     "By combining `.sel()`, `.isel()` and the various plotting methods, you can create customized \n",
     "visualizations that exactly fit your analysis needs.\n",
     "\n",
-    "> [!TIP]\n",
-    "> You can chain selections together: `ds.sel(species=\"species_1\").isel(time=slice(0, 100))` \n",
-    "> to first select by label and then by index."
+    "```{tip}\n",
+    "You can chain selections together: `ds.sel(species=\"species_1\").isel(time=slice(0, 100))` \n",
+    "to first select by label and then by index.\n",
+    "```"
    ]
   },
   {
@@ -314,8 +316,9 @@
     "\n",
     "One of the most common plot customizations besides data selection is changing the plot style.\n",
     "\n",
-    "> [!NOTE]\n",
-    "> For more information on how to use `cycler` have a look at the [`matplotlib` documentation](https://matplotlib.org/cycler/)."
+    "```{note}\n",
+    "For more information on how to use `cycler` have a look at the [`matplotlib` documentation](https://matplotlib.org/cycler/).\n",
+    "```"
    ]
   },
   {
@@ -445,7 +448,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inspect_cycler(small_cycler *cycler(linestyle=[\":\"]))"
+    "inspect_cycler(small_cycler * cycler(linestyle=[\":\"]))"
    ]
   },
   {
@@ -463,15 +466,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inspect_cycler(small_cycler*cycler(linestyle=[\"-\",\":\"]))"
+    "inspect_cycler(small_cycler * cycler(linestyle=[\"-\", \":\"]))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> [!IMPORTANT]\n",
-    "> Same as in math the **outer product** isn't commutative, so the order matters!"
+    "```{important}\n",
+    "Same as in math the **outer product** isn't commutative, so the order matters!\n",
+    "```"
    ]
   },
   {
@@ -480,7 +484,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inspect_cycler(cycler(linestyle=[\"-\",\":\"]) * small_cycler)"
+    "inspect_cycler(cycler(linestyle=[\"-\", \":\"]) * small_cycler)"
    ]
   },
   {
@@ -522,7 +526,8 @@
     "from pyglotaran_extras.plotting.style import PlotStyle\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "custom_cycler = PlotStyle().cycler[:3] + cycler(linestyle=[\"-\",\":\", \"--\"])\n",
+    "custom_cycler = PlotStyle().cycler[:3] + cycler(linestyle=[\"-\", \":\", \"--\"])\n",
+    "\n",
     "\n",
     "def plot_concentration_and_spectra(result_dataset):\n",
     "    fig, axes = plt.subplots(1, 2, figsize=(15, 4))\n",
@@ -531,7 +536,7 @@
     "    return fig, axes\n",
     "\n",
     "\n",
-    "fig, axes = plot_concentration_and_spectra(ds.isel(time=slice(100,None)))\n",
+    "fig, axes = plot_concentration_and_spectra(ds.isel(time=slice(100, None)))\n",
     "axes[0].set_xlabel(\"Time (ps)\")\n",
     "axes[0].set_ylabel(\"\")\n",
     "axes[0].axhline(0, color=\"k\", linewidth=0.5)\n",
@@ -546,8 +551,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> [!TIP]\n",
-    "> To reduce repetition check out the [documentation on using plot config](../config/project/subproject/config_docs.ipynb) and how to use it for your own plot functions ([`use_plot_config`](../../api/pyglotaran_extras/pyglotaran_extras.config.plot_config.html#pyglotaran_extras.config.plot_config.use_plot_config))."
+    "```{tip}\n",
+    "To reduce repetition check out the [documentation on using plot config](../config/project/subproject/config_docs.ipynb) and \n",
+    "how to use it for your own plot functions ([`use_plot_config`](../../api/pyglotaran_extras/pyglotaran_extras.config.plot_config.html#pyglotaran_extras.config.plot_config.use_plot_config)).\n",
+    "```"
    ]
   }
  ],

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # Set shell for Windows compatibility
-set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
 
 # Default recipe (show available recipes)
 default:

--- a/pyglotaran_extras/inspect/__init__.py
+++ b/pyglotaran_extras/inspect/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from pyglotaran_extras.inspect.a_matrix import show_a_matrixes
+from pyglotaran_extras.inspect.cycler import inspect_cycler
 
-__all__ = ["show_a_matrixes"]
+__all__ = ["inspect_cycler", "show_a_matrixes"]

--- a/pyglotaran_extras/inspect/cycler.py
+++ b/pyglotaran_extras/inspect/cycler.py
@@ -1,0 +1,77 @@
+"""Module containing functionality to inspect plot cyclers.
+
+This was inspired by:
+https://matplotlib.org/stable/gallery/lines_bars_and_markers/linestyles.html
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import matplotlib.pyplot as plt
+from cycler import Cycler
+from cycler import cycler as cycler_func
+from glotaran.utils.ipython import MarkdownStr
+from tabulate import tabulate
+
+
+def create_preview_cycler(cycler: Cycler) -> Cycler:
+    """Create a cycler with preview images of plotstyles, as HTML ``img`` tags.
+
+    The actual image in the ``img`` tag is stored as base64 encoded string.
+
+    Parameters
+    ----------
+    cycler : Cycler
+        Cycler to generate the preview for.
+
+    Returns
+    -------
+    Cycler
+        Preview images as HTML ``img`` with image data stored as base64 string.
+
+    See Also
+    --------
+    inspect_cycler
+    """
+    preview_images = []
+    buffer = io.BytesIO()
+    x, y = list(range(10)), [0] * 10
+    fig, ax = plt.subplots(1, 1, figsize=(0.5, 0.15))
+    ax.tick_params(left=False, bottom=False, labelbottom=False)
+    ax.spines[:].set_visible(False)
+    for values in cycler:
+        ax.plot(x, y, **values)
+        ax.get_yaxis().set_ticks([])
+        buffer.seek(0)
+        fig.savefig(buffer, format="jpg")
+        buffer.seek(0)
+        preview_images.append(
+            f'<img src="data:image/jpg;base64, {base64.b64encode(buffer.read()).decode()}">'
+        )
+        ax.cla()
+    plt.close()
+    return cycler_func(preview=preview_images)
+
+
+def inspect_cycler(cycler: Cycler) -> MarkdownStr:
+    """Inspect a plotstyle ``cycler`` as a markdown table including a preview.
+
+    Parameters
+    ----------
+    cycler : Cycler
+        Plotstyle cycler to inspect.
+
+    Returns
+    -------
+    MarkdownStr
+    """
+    return MarkdownStr(
+        tabulate(
+            list(cycler + create_preview_cycler(cycler)),
+            tablefmt="unsafehtml",
+            showindex="always",
+            headers="keys",
+        )
+    )

--- a/pyglotaran_extras/inspect/cycler.py
+++ b/pyglotaran_extras/inspect/cycler.py
@@ -46,6 +46,7 @@ def create_preview_cycler(cycler: Cycler) -> Cycler:
         ax.get_yaxis().set_ticks([])
         buffer.seek(0)
         fig.savefig(buffer, format="jpg")
+        buffer.truncate()
         buffer.seek(0)
         preview_images.append(
             f'<img src="data:image/jpg;base64, {base64.b64encode(buffer.read()).decode()}">'

--- a/pyglotaran_extras/plotting/plot_concentrations.py
+++ b/pyglotaran_extras/plotting/plot_concentrations.py
@@ -54,7 +54,7 @@ def plot_concentrations(
         Index of the main ``irf`` component when using an ``irf``
         parametrized with multiple peaks. Defaults to 0.
     cycler : Cycler | None
-        Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
+        Plot style cycler to use. Defaults to PlotStyle().cycler.
     title : str
         Title used for the plot axis. Defaults to "Concentrations".
 

--- a/pyglotaran_extras/plotting/plot_concentrations.py
+++ b/pyglotaran_extras/plotting/plot_concentrations.py
@@ -27,7 +27,6 @@ def plot_concentrations(
     main_irf_nr: int = 0,
     cycler: Cycler | None = PlotStyle().cycler,
     title: str = "Concentrations",
-    selected_species: list[str] | None = None,
 ) -> None:
     """Plot traces on the given axis ``ax``.
 
@@ -58,8 +57,6 @@ def plot_concentrations(
         Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
     title : str
         Title used for the plot axis. Defaults to "Concentrations".
-    selected_species : list[str] | None
-        List of species to plot. If None, plot all species. Defaults to None.
 
     See Also
     --------
@@ -67,9 +64,6 @@ def plot_concentrations(
     """
     add_cycler_if_not_none(ax, cycler)
     traces = get_shifted_traces(res, center_λ, main_irf_nr)
-
-    if selected_species is not None:
-        traces = traces.sel(species=selected_species)
 
     if "spectral" in traces.coords:
         traces.sel(spectral=center_λ, method="nearest").plot.line(x="time", ax=ax)

--- a/pyglotaran_extras/plotting/plot_concentrations.py
+++ b/pyglotaran_extras/plotting/plot_concentrations.py
@@ -27,6 +27,8 @@ def plot_concentrations(
     main_irf_nr: int = 0,
     cycler: Cycler | None = PlotStyle().cycler,
     title: str = "Concentrations",
+    selected_species: list[str] | None = None,
+    linetype: str = '-'
 ) -> None:
     """Plot traces on the given axis ``ax``.
 
@@ -57,6 +59,10 @@ def plot_concentrations(
         Plot style cycler to use. Defaults to PlotStyle().data_cycler_solid.
     title : str
         Title used for the plot axis. Defaults to "Concentrations".
+    selected_species : list[str] | None
+        List of species to plot. If None, plot all species. Defaults to None.
+    linetype : str, optional
+        Line type for the plot. Defaults to '-'.
 
     See Also
     --------
@@ -65,10 +71,13 @@ def plot_concentrations(
     add_cycler_if_not_none(ax, cycler)
     traces = get_shifted_traces(res, center_λ, main_irf_nr)
 
+    if selected_species is not None:
+        traces = traces.sel(species=selected_species)
+
     if "spectral" in traces.coords:
-        traces.sel(spectral=center_λ, method="nearest").plot.line(x="time", ax=ax)
+        traces.sel(spectral=center_λ, method="nearest").plot.line(x="time", ax=ax, linestyle=linetype)
     else:
-        traces.plot.line(x="time", ax=ax)
+        traces.plot.line(x="time", ax=ax, linestyle=linetype)
     ax.set_title(title)
 
     if linlog:

--- a/pyglotaran_extras/plotting/plot_concentrations.py
+++ b/pyglotaran_extras/plotting/plot_concentrations.py
@@ -28,7 +28,6 @@ def plot_concentrations(
     cycler: Cycler | None = PlotStyle().cycler,
     title: str = "Concentrations",
     selected_species: list[str] | None = None,
-    linetype: str = '-'
 ) -> None:
     """Plot traces on the given axis ``ax``.
 
@@ -61,8 +60,6 @@ def plot_concentrations(
         Title used for the plot axis. Defaults to "Concentrations".
     selected_species : list[str] | None
         List of species to plot. If None, plot all species. Defaults to None.
-    linetype : str, optional
-        Line type for the plot. Defaults to '-'.
 
     See Also
     --------
@@ -75,9 +72,9 @@ def plot_concentrations(
         traces = traces.sel(species=selected_species)
 
     if "spectral" in traces.coords:
-        traces.sel(spectral=center_λ, method="nearest").plot.line(x="time", ax=ax, linestyle=linetype)
+        traces.sel(spectral=center_λ, method="nearest").plot.line(x="time", ax=ax)
     else:
-        traces.plot.line(x="time", ax=ax, linestyle=linetype)
+        traces.plot.line(x="time", ax=ax)
     ax.set_title(title)
 
     if linlog:

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -78,16 +78,20 @@ def plot_sas(
     scale_factors : dict[str, float] | None
         Dictionary of species to scale and their corresponding factors. Defaults to None.
     """
+    if scale_factors is None:
+        scale_factors = {}
     add_cycler_if_not_none(ax, cycler)
     keys = [
         v for v in res.data_vars if v.startswith(("species_associated_spectra", "species_spectra"))
     ]
     for key in reversed(keys):
         sas = res[key]
-        for zorder, species in zip(range(100)[::-1], sas.coords["species"], strict=False):
+        for zorder, species in zip(
+            range(100)[::-1], sas.coords["species"].to_numpy(), strict=False
+        ):
             data = sas.sel(species=species)
-            if scale_factors and species in scale_factors:
-                data = data * scale_factors[species]
+            if (scale_factor := scale_factors.get(species)) is not None:
+                data *= scale_factor
             data.plot.line(x="spectral", ax=ax, zorder=zorder)
     ax.set_title(title)
     if show_zero_line is True:

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -59,7 +59,6 @@ def plot_sas(
     title: str = "SAS",
     cycler: Cycler | None = PlotStyle().cycler,
     show_zero_line: bool = True,
-    selected_species: list[str] | None = None,
     scale_factors: dict[str, float] | None = None,
 ) -> None:
     """Plot SAS (Species Associated Spectra) on ``ax``.
@@ -76,8 +75,6 @@ def plot_sas(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
-    selected_species : list[str] | None
-        List of species to plot. If None, plot all species. Defaults to None.
     scale_factors : dict[str, float] | None
         Dictionary of species to scale and their corresponding factors. Defaults to None.
     """
@@ -87,10 +84,7 @@ def plot_sas(
     ]
     for key in reversed(keys):
         sas = res[key]
-        species_to_plot = (
-            selected_species if selected_species is not None else sas.coords["species"]
-        )
-        for zorder, species in zip(range(100)[::-1], species_to_plot, strict=False):
+        for zorder, species in zip(range(100)[::-1], sas.coords["species"], strict=False):
             data = sas.sel(species=species)
             if scale_factors and species in scale_factors:
                 data = data * scale_factors[species]
@@ -107,7 +101,6 @@ def plot_norm_sas(
     title: str = "norm SAS",
     cycler: Cycler | None = PlotStyle().cycler,
     show_zero_line: bool = True,
-    selected_species: list[str] | None = None,
 ) -> None:
     """Plot normalized SAS (Species Associated Spectra) on ``ax``.
 
@@ -123,8 +116,6 @@ def plot_norm_sas(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
-    selected_species : list[str] | None
-        List of species to plot. If None, plot all species. Defaults to None.
     """
     add_cycler_if_not_none(ax, cycler)
     keys = [
@@ -132,12 +123,10 @@ def plot_norm_sas(
     ]
     for key in keys:
         sas = res[key]
-        species_to_plot = (
-            selected_species if selected_species is not None else sas.coords["species"]
-        )
-        for zorder, species in zip(range(100)[::-1], species_to_plot, strict=False):
-            data = sas.sel(species=species)
-            (data / np.abs(data).max(dim="spectral")).plot.line(x="spectral", ax=ax, zorder=zorder)
+        for zorder, species in zip(range(100)[::-1], sas.coords["species"], strict=False):
+            (sas / np.abs(sas).max(dim="spectral")).sel(species=species).plot.line(
+                x="spectral", ax=ax, zorder=zorder
+            )
         ax.set_title(title)
     if show_zero_line is True:
         ax.axhline(0, color="k", linewidth=1)

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -127,7 +127,9 @@ def plot_norm_sas(
     ]
     for key in keys:
         sas = res[key]
-        for zorder, species in zip(range(100)[::-1], sas.coords["species"], strict=False):
+        for zorder, species in zip(
+            range(100)[::-1], sas.coords["species"].to_numpy(), strict=False
+        ):
             (sas / np.abs(sas).max(dim="spectral")).sel(species=species).plot.line(
                 x="spectral", ax=ax, zorder=zorder
             )

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -91,8 +91,9 @@ def plot_sas(
         ):
             data = sas.sel(species=species)
             if (scale_factor := scale_factors.get(species)) is not None:
-                data *= scale_factor
-            data.plot.line(x="spectral", ax=ax, zorder=zorder)
+                (data * scale_factor).plot.line(x="spectral", ax=ax, zorder=zorder)
+            else:
+                data.plot.line(x="spectral", ax=ax, zorder=zorder)
     ax.set_title(title)
     if show_zero_line is True:
         ax.axhline(0, color="k", linewidth=1)

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -53,44 +53,6 @@ def plot_spectra(
 
 
 @use_plot_config(exclude_from_config=("cycler",))
-# def plot_sas(
-#     res: xr.Dataset,
-#     ax: Axis,
-#     title: str = "SAS",
-#     cycler: Cycler | None = PlotStyle().cycler,
-#     show_zero_line: bool = True,
-#     selected_species: list[str] | None = None,
-# ) -> None:
-#     """Plot SAS (Species Associated Spectra) on ``ax``.
-
-#     Parameters
-#     ----------
-#     res : xr.Dataset
-#         Result dataset
-#     ax : Axis
-#         Axis to plot on.
-#     title : str
-#         Title of the plot. Defaults to "SAS".
-#     cycler : Cycler | None
-#         Plot style cycler to use. Defaults to PlotStyle().cycler.
-#     show_zero_line : bool
-#         Whether or not to add a horizontal line at zero. Defaults to True.
-#     selected_species : list[str] | None
-#         List of species to plot. If None, plot all species. Defaults to None.
-#     """
-#     add_cycler_if_not_none(ax, cycler)
-#     keys = [
-#         v for v in res.data_vars if v.startswith(("species_associated_spectra", "species_spectra"))
-#     ]
-#     for key in reversed(keys):
-#         sas = res[key]
-#         species_to_plot = selected_species if selected_species is not None else sas.coords["species"]
-#     for zorder, species in zip(range(100)[::-1], species_to_plot, strict=False):
-#             sas.sel(species=species).plot.line(x="spectral", ax=ax, zorder=zorder)
-#     ax.set_title(title)
-#     if show_zero_line is True:
-#         ax.axhline(0, color="k", linewidth=1)
-
 def plot_sas(
     res: xr.Dataset,
     ax: Axes,
@@ -118,8 +80,6 @@ def plot_sas(
         List of species to plot. If None, plot all species. Defaults to None.
     scale_factors : dict[str, float] | None
         Dictionary of species to scale and their corresponding factors. Defaults to None.
-    NB The current implementation of the plot_sas function does only apply scale factors when 
-    selected_species is not None. This is because the check for scale_factors is nested within the if selected_species is not None condition.
     """
     add_cycler_if_not_none(ax, cycler)
     keys = [
@@ -127,7 +87,9 @@ def plot_sas(
     ]
     for key in reversed(keys):
         sas = res[key]
-        species_to_plot = selected_species if selected_species is not None else sas.coords["species"]
+        species_to_plot = (
+            selected_species if selected_species is not None else sas.coords["species"]
+        )
         for zorder, species in zip(range(100)[::-1], species_to_plot, strict=False):
             data = sas.sel(species=species)
             if scale_factors and species in scale_factors:
@@ -136,6 +98,7 @@ def plot_sas(
     ax.set_title(title)
     if show_zero_line is True:
         ax.axhline(0, color="k", linewidth=1)
+
 
 @use_plot_config(exclude_from_config=("cycler",))
 def plot_norm_sas(
@@ -169,14 +132,12 @@ def plot_norm_sas(
     ]
     for key in keys:
         sas = res[key]
-        species_to_plot = selected_species if selected_species is not None else sas.coords["species"]
+        species_to_plot = (
+            selected_species if selected_species is not None else sas.coords["species"]
+        )
         for zorder, species in zip(range(100)[::-1], species_to_plot, strict=False):
             data = sas.sel(species=species)
-            (data/ np.abs(data).max(dim="spectral")).plot.line(x="spectral", ax=ax, zorder=zorder)
-        # for zorder, species in zip(range(100)[::-1], sas.coords["species"], strict=False):
-        #     (sas / np.abs(sas).max(dim="spectral")).sel(species=species).plot.line(
-        #         x="spectral", ax=ax, zorder=zorder
-        #     )
+            (data / np.abs(data).max(dim="spectral")).plot.line(x="spectral", ax=ax, zorder=zorder)
         ax.set_title(title)
     if show_zero_line is True:
         ax.axhline(0, color="k", linewidth=1)

--- a/pyglotaran_extras/plotting/plot_spectra.py
+++ b/pyglotaran_extras/plotting/plot_spectra.py
@@ -53,12 +53,52 @@ def plot_spectra(
 
 
 @use_plot_config(exclude_from_config=("cycler",))
+# def plot_sas(
+#     res: xr.Dataset,
+#     ax: Axis,
+#     title: str = "SAS",
+#     cycler: Cycler | None = PlotStyle().cycler,
+#     show_zero_line: bool = True,
+#     selected_species: list[str] | None = None,
+# ) -> None:
+#     """Plot SAS (Species Associated Spectra) on ``ax``.
+
+#     Parameters
+#     ----------
+#     res : xr.Dataset
+#         Result dataset
+#     ax : Axis
+#         Axis to plot on.
+#     title : str
+#         Title of the plot. Defaults to "SAS".
+#     cycler : Cycler | None
+#         Plot style cycler to use. Defaults to PlotStyle().cycler.
+#     show_zero_line : bool
+#         Whether or not to add a horizontal line at zero. Defaults to True.
+#     selected_species : list[str] | None
+#         List of species to plot. If None, plot all species. Defaults to None.
+#     """
+#     add_cycler_if_not_none(ax, cycler)
+#     keys = [
+#         v for v in res.data_vars if v.startswith(("species_associated_spectra", "species_spectra"))
+#     ]
+#     for key in reversed(keys):
+#         sas = res[key]
+#         species_to_plot = selected_species if selected_species is not None else sas.coords["species"]
+#     for zorder, species in zip(range(100)[::-1], species_to_plot, strict=False):
+#             sas.sel(species=species).plot.line(x="spectral", ax=ax, zorder=zorder)
+#     ax.set_title(title)
+#     if show_zero_line is True:
+#         ax.axhline(0, color="k", linewidth=1)
+
 def plot_sas(
     res: xr.Dataset,
     ax: Axes,
     title: str = "SAS",
     cycler: Cycler | None = PlotStyle().cycler,
     show_zero_line: bool = True,
+    selected_species: list[str] | None = None,
+    scale_factors: dict[str, float] | None = None,
 ) -> None:
     """Plot SAS (Species Associated Spectra) on ``ax``.
 
@@ -74,6 +114,12 @@ def plot_sas(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
+    selected_species : list[str] | None
+        List of species to plot. If None, plot all species. Defaults to None.
+    scale_factors : dict[str, float] | None
+        Dictionary of species to scale and their corresponding factors. Defaults to None.
+    NB The current implementation of the plot_sas function does only apply scale factors when 
+    selected_species is not None. This is because the check for scale_factors is nested within the if selected_species is not None condition.
     """
     add_cycler_if_not_none(ax, cycler)
     keys = [
@@ -81,12 +127,15 @@ def plot_sas(
     ]
     for key in reversed(keys):
         sas = res[key]
-        for zorder, species in zip(range(100)[::-1], sas.coords["species"], strict=False):
-            sas.sel(species=species).plot.line(x="spectral", ax=ax, zorder=zorder)
-        ax.set_title(title)
+        species_to_plot = selected_species if selected_species is not None else sas.coords["species"]
+        for zorder, species in zip(range(100)[::-1], species_to_plot, strict=False):
+            data = sas.sel(species=species)
+            if scale_factors and species in scale_factors:
+                data = data * scale_factors[species]
+            data.plot.line(x="spectral", ax=ax, zorder=zorder)
+    ax.set_title(title)
     if show_zero_line is True:
         ax.axhline(0, color="k", linewidth=1)
-
 
 @use_plot_config(exclude_from_config=("cycler",))
 def plot_norm_sas(
@@ -95,6 +144,7 @@ def plot_norm_sas(
     title: str = "norm SAS",
     cycler: Cycler | None = PlotStyle().cycler,
     show_zero_line: bool = True,
+    selected_species: list[str] | None = None,
 ) -> None:
     """Plot normalized SAS (Species Associated Spectra) on ``ax``.
 
@@ -110,6 +160,8 @@ def plot_norm_sas(
         Plot style cycler to use. Defaults to PlotStyle().cycler.
     show_zero_line : bool
         Whether or not to add a horizontal line at zero. Defaults to True.
+    selected_species : list[str] | None
+        List of species to plot. If None, plot all species. Defaults to None.
     """
     add_cycler_if_not_none(ax, cycler)
     keys = [
@@ -117,10 +169,14 @@ def plot_norm_sas(
     ]
     for key in keys:
         sas = res[key]
-        for zorder, species in zip(range(100)[::-1], sas.coords["species"], strict=False):
-            (sas / np.abs(sas).max(dim="spectral")).sel(species=species).plot.line(
-                x="spectral", ax=ax, zorder=zorder
-            )
+        species_to_plot = selected_species if selected_species is not None else sas.coords["species"]
+        for zorder, species in zip(range(100)[::-1], species_to_plot, strict=False):
+            data = sas.sel(species=species)
+            (data/ np.abs(data).max(dim="spectral")).plot.line(x="spectral", ax=ax, zorder=zorder)
+        # for zorder, species in zip(range(100)[::-1], sas.coords["species"], strict=False):
+        #     (sas / np.abs(sas).max(dim="spectral")).sel(species=species).plot.line(
+        #         x="spectral", ax=ax, zorder=zorder
+        #     )
         ax.set_title(title)
     if show_zero_line is True:
         ax.axhline(0, color="k", linewidth=1)

--- a/pyglotaran_extras/plotting/style.py
+++ b/pyglotaran_extras/plotting/style.py
@@ -104,6 +104,11 @@ class DataColorCode(str, Enum):
     indigo = "#4b0082"
     brown = "#964b00"
     maroon = "#800000"
+    # 20241231 added 2 pairs to allow plotting 9 different data sets
+    olive = "#808000"
+    olive4 = "#556b2f"
+    turquoise = "#40e0d0"
+    turquoise4 = "#00ced1"
     yellow = "#ffff00"
     # Adding orange a second time needs to be added manually to the list in PlotStyle
     # since Enum doesn't allow duplicates

--- a/pyglotaran_extras/plotting/style.py
+++ b/pyglotaran_extras/plotting/style.py
@@ -104,7 +104,6 @@ class DataColorCode(str, Enum):
     indigo = "#4b0082"
     brown = "#964b00"
     maroon = "#800000"
-    # 20241231 added 2 pairs to allow plotting 9 different data sets
     olive = "#808000"
     olive4 = "#556b2f"
     turquoise = "#40e0d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,13 +110,17 @@ paths.source = [
 ]
 # Regexes for lines to exclude from consideration
 report.exclude_lines = [
-  " Don't complain about missing debug-only code",
-  " Don't complain if non-runnable code isn't run",
-  " Don't complain if tests don't hit defensive assertion code",
-  " Have to re-enable the standard pragm",
+  # Don't complain about missing debug-only code:
+  "def __repr__",
   "if __name__ == .__main__.:",
+  # Don't complain if non-runnable code isn't run:
+  "if 0:",
   "if self\\.debug",
   "if TYPE_CHECKING:",
+  # Have to re-enable the standard pragma
+  "pragma: no cover",
+  # Don't complain if tests don't hit defensive assertion code:
+  "raise AssertionError",
   "raise NotImplementedError",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,9 @@ dependencies = [
   "tabulate>=0.8.9",
   "xarray>=2022.3",
 ]
+urls."GloTarAn Ecosystem" = "https://glotaran.org"
 urls.Changelog = "https://pyglotaran-extras.readthedocs.io/en/latest/changelog.html"
 urls.Documentation = "https://pyglotaran-extras.readthedocs.io"
-urls."GloTarAn Ecosystem" = "https://glotaran.org"
 urls.Homepage = "https://github.com/glotaran/pyglotaran-extras"
 urls.Source = "https://github.com/glotaran/pyglotaran-extras"
 urls.Tracker = "https://github.com/glotaran/pyglotaran-extras/issues"
@@ -75,16 +75,14 @@ docs = [
   "sphinxcontrib-mermaid>=0.9.2",
 ]
 
-[tool.hatch.version]
-path = "pyglotaran_extras/__init__.py"
-
-[tool.hatch.build.targets.sdist]
-include = [
+[tool.hatch]
+build.targets.sdist.include = [
   "/pyglotaran_extras",
   "/docs",
   "/tests",
   "changelog.md",
 ]
+version.path = "pyglotaran_extras/__init__.py"
 
 [tool.docformatter]
 black = true
@@ -95,41 +93,31 @@ wrap-descriptions = 99
 
 [tool.pydoclint]
 skip-checking-short-docstrings = false
-style = 'numpy'
-exclude = '^(docs/|tests?/)'
+style = "numpy"
+exclude = "^(docs/|tests?/)"
 require-return-section-when-returning-none = false
 allow-init-docstring = true
 
-[tool.coverage.paths]
-source = [
+[tool.coverage]
+run.branch = true
+run.omit = [
+  "tests/*",
+  # comment the above line if you want to see if all tests did run
+]
+paths.source = [
   "pyglotaran_extras",
   "*/site-packages/pyglotaran_extras",
 ]
-[tool.coverage.run]
-branch = true
-omit = [
-  'tests/*',
-  # comment the above line if you want to see if all tests did run
-]
-
-[tool.coverage.report]
 # Regexes for lines to exclude from consideration
-exclude_lines = [
-  # Have to re-enable the standard pragma
-  'pragma: no cover',
-
-  # Don't complain about missing debug-only code:
-  'def __repr__',
-  'if self\.debug',
-
-  # Don't complain if tests don't hit defensive assertion code:
-  'raise AssertionError',
-  'raise NotImplementedError',
-
-  # Don't complain if non-runnable code isn't run:
-  'if 0:',
-  'if __name__ == .__main__.:',
-  'if TYPE_CHECKING:',
+report.exclude_lines = [
+  " Don't complain about missing debug-only code",
+  " Don't complain if non-runnable code isn't run",
+  " Don't complain if tests don't hit defensive assertion code",
+  " Have to re-enable the standard pragm",
+  "if __name__ == .__main__.:",
+  "if self\\.debug",
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
 ]
 
 [tool.mypy]
@@ -148,11 +136,9 @@ disallow_untyped_calls = true
 no_implicit_reexport = true
 warn_unused_configs = true
 check_untyped_defs = true
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_incomplete_defs = false
-disallow_untyped_defs = false
+overrides = [
+  { module = "tests.*", disallow_incomplete_defs = false, disallow_untyped_defs = false },
+]
 
 [tool.interrogate]
 exclude = [


### PR DESCRIPTION
This change adds the new functionality requested by @ism200 .

As discussed in the initial request, I removed the additional arguments, which can be easily achieved using data selection or changing the cycler.

The reasoning for the removal is that we should rather teach users to help themselves do basic operations than add more function arguments, which increases the cognitive load and causes option fatigue.

Thus, I added a new documentation section "Going beyond builtin" explaining the basics of data selection and how to work with cyclers.

### Change summary

- Add `scale_factors` argument to `plot_sas` for scaling control
- Add 2 additional data color pairs
- Add `inspect_cycler` utility function

### Links to the changed docs sections

- [Going beyond builtin](https://pyglotaran-extras--394.org.readthedocs.build/en/394/notebooks/tips_and_tricks.html)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 📚 Adds documentation of the feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspect and preview matplotlib color cycles with inline thumbnails
  * Per-species scaling option for spectral plots
  * Four new plot color choices added

* **Documentation**
  * New "tips and tricks" notebook added to docs navigation with advanced plotting workflows
  * Dark-mode CSS improvements for notebook rendering

* **Chores**
  * Updated project/config files and pre-commit tool versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->